### PR TITLE
Fix Dockerfile to use JSON arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 FROM gradle:latest AS builder
 # ^ 2 Critical & 4 High vulnerabilities, as per Docker DX (14.08.2025)
-ADD https://github.com/d4rken/octi-sync-server-kotlin.git /octi-k-server
-WORKDIR /octi-k-server
+ADD https://github.com/d4rken/octi-sync-server-kotlin.git /octi-sync-server
+WORKDIR /octi-sync-server
 RUN ./gradlew clean installDist
 
 FROM openjdk:26-jdk
 RUN microdnf install findutils -y
-WORKDIR /octi-k-server
-COPY --from=builder /octi-k-server/build/install/octi-sync-server-kotlin/ .
-ENTRYPOINT ./bin/octi-sync-server-kotlin --datapath=${OCTI_DATAPATH:-/etc/octi-k-server} --port=${OCTI_PORT:-8080}
-# Entrypoint is in sh mode, for env compatability, otherwise the built image can't start
+WORKDIR /octi-sync-server
+COPY --from=builder /octi-sync-server/build/install/octi-sync-server-kotlin/ .
+
+# Set default environment variables
+ENV OCTI_DATAPATH=/etc/octi-sync-server
+ENV OCTI_PORT=8080
+
+# Use JSON array format for entrypoint with shell to handle env vars
+ENTRYPOINT ["sh", "-c", "./bin/octi-sync-server-kotlin --datapath=${OCTI_DATAPATH} --port=${OCTI_PORT}"]


### PR DESCRIPTION
Basically embed the defaults as ENV instructions in the Dockerfile(also make them generic), and move to a JSON arguments for the entrypoint