### PR TITLE
Another Dockerfile update 😄 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,11 @@ COPY src/ ./src/
 # Build the application
 RUN ./gradlew clean installDist --no-daemon
 
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:24-jre
 WORKDIR /octi-sync-server
 
-# Create non-root user for security
-RUN useradd -r -u 1000 octi-user
+# Create non-root user for security (let system assign UID)
+RUN useradd -r -s /bin/bash octi-user
 
 # Copy built application
 COPY --from=builder /octi-sync-server/build/install/octi-sync-server-kotlin/ .

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM eclipse-temurin:24-jre
 WORKDIR /octi-sync-server
 
 # Create non-root user for security (let system assign UID)
-RUN useradd -r -s /bin/bash octi-user
+RUN useradd -r -s /bin/bash -m octi-user
 
 # Copy built application
 COPY --from=builder /octi-sync-server/build/install/octi-sync-server-kotlin/ .
@@ -36,14 +36,21 @@ COPY --from=builder /octi-sync-server/build/install/octi-sync-server-kotlin/ .
 # Copy entrypoint script
 COPY docker-entrypoint.sh .
 
-# Fix line endings and set ownership and make executable
-RUN sed -i 's/\r$//' ./docker-entrypoint.sh && \
-    chown -R octi-user:octi-user /octi-sync-server && \
+# Create data directory and set permissions
+RUN mkdir -p /etc/octi-sync-server && \
+    sed -i 's/\r$//' ./docker-entrypoint.sh && \
+    chown -R octi-user:octi-user /octi-sync-server /etc/octi-sync-server && \
     chmod +x ./bin/octi-sync-server-kotlin && \
     chmod +x ./docker-entrypoint.sh
 
 # Switch to non-root user
 USER octi-user
+
+# Expose the application port
+EXPOSE 8080
+
+# Declare volume for data persistence
+VOLUME ["/etc/octi-sync-server"]
 
 # Use the entrypoint script
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,59 @@
 FROM gradle:latest AS builder
 # ^ 2 Critical & 4 High vulnerabilities, as per Docker DX (14.08.2025)
-ADD https://github.com/d4rken/octi-sync-server-kotlin.git /octi-sync-server
 WORKDIR /octi-sync-server
-RUN ./gradlew clean installDist
+
+# Copy Gradle wrapper files first for better caching
+COPY gradlew ./
+COPY gradlew.bat ./
+COPY gradle/ ./gradle/
+
+# Convert line endings and make gradlew executable (fixes Windows CRLF issues)
+RUN sed -i 's/\r$//' ./gradlew && chmod +x ./gradlew
+
+# Copy build files for dependency resolution
+COPY build.gradle.kts ./
+COPY settings.gradle.kts ./
+COPY gradle.properties ./
+
+# Download dependencies (cached layer)
+RUN ./gradlew dependencies --no-daemon
+
+# Copy source code
+COPY src/ ./src/
+
+# Build the application
+RUN ./gradlew clean installDist --no-daemon
 
 FROM openjdk:26-jdk
-RUN microdnf install findutils -y
+
+# Install findutils and create non-root user for security
+RUN microdnf install findutils -y && \
+    microdnf clean all && \
+    useradd -r -u 1000 octi-user
+
 WORKDIR /octi-sync-server
+
+# Copy built application
 COPY --from=builder /octi-sync-server/build/install/octi-sync-server-kotlin/ .
+
+# Set ownership and make executable
+RUN chown -R octi-user:octi-user /octi-sync-server && \
+    chmod +x ./bin/octi-sync-server-kotlin
+
+# Create data directory
+RUN mkdir -p /etc/octi-sync-server && \
+    chown -R octi-user:octi-user /etc/octi-sync-server
+
+# Switch to non-root user
+USER octi-user
 
 # Set default environment variables
 ENV OCTI_DATAPATH=/etc/octi-sync-server
 ENV OCTI_PORT=8080
+
+# Expose port
+# EXPOSE 8080
+# ^ Why tho?
 
 # Use JSON array format for entrypoint with shell to handle env vars
 ENTRYPOINT ["sh", "-c", "./bin/octi-sync-server-kotlin --datapath=${OCTI_DATAPATH} --port=${OCTI_PORT}"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,56 +3,20 @@
 # Octi Sync Server Entrypoint Script
 #
 # Environment variables:
-# - OCTI_DATAPATH: Path to store server data (default: /etc/octi-sync-server)
-# - OCTI_PORT: Server port (default: 8080)
 # - OCTI_DEBUG: Enable debug mode (default: false)
 #
-# The script will:
-# 1. Validate environment variables
-# 2. Create data directory if it doesn't exist
-# 3. Check directory permissions
-# 4. Start the application with appropriate flags
+# Fixed configuration:
+# - Data Path: /etc/octi-sync-server
+# - Port: 8080
 #
 
 set -e
 
-# Default values
-DEFAULT_PORT=8080
-DEFAULT_DATAPATH="/etc/octi-sync-server"
-
 # Process environment variables
-OCTI_PORT=${OCTI_PORT:-$DEFAULT_PORT}
-OCTI_DATAPATH=${OCTI_DATAPATH:-$DEFAULT_DATAPATH}
 OCTI_DEBUG=${OCTI_DEBUG:-false}
 
-# Validation functions
-validate_port() {
-    if ! [[ "$OCTI_PORT" =~ ^[0-9]+$ ]] || [ "$OCTI_PORT" -lt 1024 ] || [ "$OCTI_PORT" -gt 65535 ]; then
-        echo "Error: Invalid port number. Must be between 1024-65535"
-        exit 1
-    fi
-}
-
-validate_datapath() {
-    if [ ! -d "$OCTI_DATAPATH" ]; then
-        echo "Creating data directory: $OCTI_DATAPATH"
-        mkdir -p "$OCTI_DATAPATH"
-        chown -R octi-user:octi-user "$OCTI_DATAPATH"
-        CHMOD -R +w:octi-user "$OCTI_DATAPATH"
-    fi
-    
-    if [ ! -w "$OCTI_DATAPATH" ]; then
-        echo "Error: Data directory is not writable: $OCTI_DATAPATH"
-        exit 1
-    fi
-}
-
-# Validate inputs
-validate_port
-validate_datapath
-
-# Build command arguments
-CMD_ARGS="--datapath=$OCTI_DATAPATH --port=$OCTI_PORT"
+# Fixed arguments
+CMD_ARGS="--datapath=/etc/ocit-sync-server --port=8080"
 
 # Add debug flag if enabled
 if [ "$OCTI_DEBUG" = "true" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -37,6 +37,8 @@ validate_datapath() {
     if [ ! -d "$OCTI_DATAPATH" ]; then
         echo "Creating data directory: $OCTI_DATAPATH"
         mkdir -p "$OCTI_DATAPATH"
+        chown -R octi-user:octi-user "$OCTI_DATAPATH"
+        CHMOD -R +w:octi-user "$OCTI_DATAPATH"
     fi
     
     if [ ! -w "$OCTI_DATAPATH" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Octi Sync Server Entrypoint Script
+#
+# Environment variables:
+# - OCTI_DATAPATH: Path to store server data (default: /etc/octi-sync-server)
+# - OCTI_PORT: Server port (default: 8080)
+# - OCTI_DEBUG: Enable debug mode (default: false)
+#
+# The script will:
+# 1. Validate environment variables
+# 2. Create data directory if it doesn't exist
+# 3. Check directory permissions
+# 4. Start the application with appropriate flags
+#
+
+set -e
+
+# Default values
+DEFAULT_PORT=8080
+DEFAULT_DATAPATH="/etc/octi-sync-server"
+
+# Process environment variables
+OCTI_PORT=${OCTI_PORT:-$DEFAULT_PORT}
+OCTI_DATAPATH=${OCTI_DATAPATH:-$DEFAULT_DATAPATH}
+OCTI_DEBUG=${OCTI_DEBUG:-false}
+
+# Validation functions
+validate_port() {
+    if ! [[ "$OCTI_PORT" =~ ^[0-9]+$ ]] || [ "$OCTI_PORT" -lt 1024 ] || [ "$OCTI_PORT" -gt 65535 ]; then
+        echo "Error: Invalid port number. Must be between 1024-65535"
+        exit 1
+    fi
+}
+
+validate_datapath() {
+    if [ ! -d "$OCTI_DATAPATH" ]; then
+        echo "Creating data directory: $OCTI_DATAPATH"
+        mkdir -p "$OCTI_DATAPATH"
+    fi
+    
+    if [ ! -w "$OCTI_DATAPATH" ]; then
+        echo "Error: Data directory is not writable: $OCTI_DATAPATH"
+        exit 1
+    fi
+}
+
+# Validate inputs
+validate_port
+validate_datapath
+
+# Build command arguments
+CMD_ARGS="--datapath=$OCTI_DATAPATH --port=$OCTI_PORT"
+
+# Add debug flag if enabled
+if [ "$OCTI_DEBUG" = "true" ]; then
+    CMD_ARGS="$CMD_ARGS --debug"
+fi
+
+# Execute the application
+exec ./bin/octi-sync-server-kotlin $CMD_ARGS

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,20 +3,27 @@
 # Octi Sync Server Entrypoint Script
 #
 # Environment variables:
+# - OCTI_PORT: Server port (default: 8080)
 # - OCTI_DEBUG: Enable debug mode (default: false)
 #
 # Fixed configuration:
 # - Data Path: /etc/octi-sync-server
-# - Port: 8080
 #
 
 set -e
 
 # Process environment variables
+OCTI_PORT=${OCTI_PORT:-8080}
 OCTI_DEBUG=${OCTI_DEBUG:-false}
 
-# Fixed arguments
-CMD_ARGS="--datapath=/etc/ocit-sync-server --port=8080"
+# Validate port
+if ! [[ "$OCTI_PORT" =~ ^[0-9]+$ ]] || [ "$OCTI_PORT" -lt 1 ] || [ "$OCTI_PORT" -gt 65535 ]; then
+    echo "Error: Invalid port number. Must be between 1-65535"
+    exit 1
+fi
+
+# Build command arguments
+CMD_ARGS="--datapath=/etc/octi-sync-server --port=$OCTI_PORT"
 
 # Add debug flag if enabled
 if [ "$OCTI_DEBUG" = "true" ]; then


### PR DESCRIPTION
- The Dockerfile uses the local codebase now instead of pulling d4rken/octi-sync-server-kotlin
- Datapath is now static
  - Dynamic datapath is a pain to work with
  - volume creation is now forced, so the datapath is writable
- Changed the openjdk:26-jdk to eclipse-temurin:24-jre, because openjdk image was deprecated
  - Smaller image after build (~490MB from ~1.01GB)
- Switched to the docker-entrypoint.sh trick to improve the startup
  - `OCTI_DEBUG=true` adds `--debug` to the binary startup
- I laid my grubby hands on your README once again
  - Linter forced my hand
  - It's more readable tho
  - Rendered view is unchanged