### PR TITLE
Change to a fixed gradle version for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM gradle:latest AS builder
-# ^ 2 Critical & 4 High vulnerabilities (14.08.2025)
+FROM gradle:9.0 AS builder
+# ^ 2 Critical, 4 High, 23 Medium, 4 Low vulnerabilities (04.12.2025)
+# gradle 8.9, 8.10, 8.11, 8.12, 8.13 and 9.0 work
+# gradle 8.14 does nothing(doesn't build at all, no binary, no logs)
+# gradle 9.1 Fatal Errors due to some incompatability with jdk25
+# gradle 9.x with jdk21 does nothing, much like 8.14
 WORKDIR /octi-sync-server
 
 # Copy Gradle wrapper files first for better caching
@@ -25,6 +29,7 @@ COPY src/ ./src/
 RUN ./gradlew clean installDist --no-daemon
 
 FROM eclipse-temurin:24-jre
+# ^ 3 Medium, 2 Low vulnerabilities (04.12.2025)
 WORKDIR /octi-sync-server
 
 # Create non-root user for security (let system assign UID)


### PR DESCRIPTION
* Add vulnerability defenitions for eclipse-temurin:24-jre
* Update vulnerability defenitions for gradle:9.0
* Set gradle to 9.0, as the highest working version for building octi-sync-server

The commit in this PR is a squash of 19 separate commits, that test and debug different gradle versions to produce working builds

Fixes #5 