### PR TITLE
Rename project to match new repository name

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew installDist
 
       - name: Create ZIP file from the directory
-        run: zip -r octi-sync-server.zip ./build/install/octi-sync-server-kotlin
+        run: zip -r octi-server.zip ./build/install/octi-server
 
       - name: Create pre-release
         if: contains(steps.tagger.outputs.tag, '-beta')
@@ -43,7 +43,7 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: octi-sync-server.zip
+          files: octi-server.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -55,6 +55,6 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: octi-sync-server.zip
+          files: octi-server.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+octi-server

--- a/.idea/runConfigurations/App___TestData___Debug.xml
+++ b/.idea/runConfigurations/App___TestData___Debug.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="App - TestData - Debug" type="JetRunConfigurationType">
     <option name="MAIN_CLASS_NAME" value="eu.darken.octi.kserver.App" />
-    <module name="octi-sync-server-kotlin.main" />
+    <module name="octi-server.main" />
     <option name="PROGRAM_PARAMETERS" value="--debug --datapath=./zdatapath" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM gradle:8.13 AS builder
-WORKDIR /octi-sync-server
+WORKDIR /octi-server
 
 # Copy Gradle wrapper files first for better caching
 COPY gradlew ./
@@ -25,22 +25,22 @@ RUN ./gradlew clean installDist --no-daemon
 
 FROM eclipse-temurin:24-jre
 # ^ 3 Medium, 2 Low vulnerabilities (04.12.2025)
-WORKDIR /octi-sync-server
+WORKDIR /octi-server
 
 # Create non-root user for security (let system assign UID)
 RUN useradd -r -s /bin/bash -m octi-user
 
 # Copy built application
-COPY --from=builder /octi-sync-server/build/install/octi-sync-server-kotlin/ .
+COPY --from=builder /octi-server/build/install/octi-server/ .
 
 # Copy entrypoint script
 COPY docker-entrypoint.sh .
 
-# Create data directory and set permissions
-RUN mkdir -p /etc/octi-sync-server && \
+# Create data directories and set permissions
+RUN mkdir -p /etc/octi-server /etc/octi-sync-server && \
     sed -i 's/\r$//' ./docker-entrypoint.sh && \
-    chown -R octi-user:octi-user /octi-sync-server /etc/octi-sync-server && \
-    chmod +x ./bin/octi-sync-server-kotlin && \
+    chown -R octi-user:octi-user /octi-server /etc/octi-server /etc/octi-sync-server && \
+    chmod +x ./bin/octi-server && \
     chmod +x ./docker-entrypoint.sh
 
 # Switch to non-root user
@@ -50,7 +50,7 @@ USER octi-user
 EXPOSE 8080
 
 # Declare volume for data persistence
-VOLUME ["/etc/octi-sync-server"]
+VOLUME ["/etc/octi-server"]
 
 # Use the entrypoint script
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Octi Sync Server
+# Octi Server
 
-[![Code tests & eval](https://img.shields.io/github/actions/workflow/status/d4rken/octi-sync-server-kotlin/code-checks.yml?logo=githubactions&label=Code%20tests)](https://github.com/d4rken/octi-sync-server-kotlin/actions)
+[![Code tests & eval](https://img.shields.io/github/actions/workflow/status/d4rken-org/octi-server/code-checks.yml?logo=githubactions&label=Code%20tests)](https://github.com/d4rken-org/octi-server/actions)
 
 This is a synchronization server for [Octi](https://github.com/d4rken-org/octi)
 
@@ -12,13 +12,13 @@ This is a synchronization server for [Octi](https://github.com/d4rken-org/octi)
 ./gradlew clean installDist
 ```
 
-The binaries you can copy to a server will be placed under `./build/install/octi-sync-server-kotlin`.
+The binaries you can copy to a server will be placed under `./build/install/octi-server`.
 More details [here](https://ktor.io/docs/server-packaging.html).
 
 ### Run server
 
 ```bash
-./build/install/octi-sync-server-kotlin/bin/octi-sync-server-kotlin --datapath=./octi-data
+./build/install/octi-server/bin/octi-server --datapath=./octi-data
 ```
 
 The following flags are available:
@@ -26,3 +26,19 @@ The following flags are available:
 * `--datapath` (required) where the server should store its data
 * `--debug` to enable additional log output
 * `--port` to change the default port (8080)
+
+### Docker
+
+The default data volume is `/etc/octi-server`.
+
+```bash
+docker run -v octi-data:/etc/octi-server -p 8080:8080 ghcr.io/d4rken-org/octi-server
+```
+
+Environment variables:
+
+* `OCTI_PORT` — server port (default: 8080)
+* `OCTI_DEBUG` — enable debug mode (default: false)
+* `OCTI_DATA_DIR` — override data directory path
+
+**Migrating from `/etc/octi-sync-server`**: The old volume path is still detected automatically. Update your mount to `/etc/octi-server` when convenient, or set `OCTI_DATA_DIR` explicitly.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 #
-# Octi Sync Server Entrypoint Script
+# Octi Server Entrypoint Script
 #
 # Environment variables:
 # - OCTI_PORT: Server port (default: 8080)
 # - OCTI_DEBUG: Enable debug mode (default: false)
+# - OCTI_DATA_DIR: Override data directory path (default: auto-detect)
 #
-# Fixed configuration:
-# - Data Path: /etc/octi-sync-server
+# Default data path: /etc/octi-server
+# Deprecated path: /etc/octi-sync-server (still supported via auto-detection)
 #
 
 set -e
@@ -22,8 +23,25 @@ if ! [[ "$OCTI_PORT" =~ ^[0-9]+$ ]] || [ "$OCTI_PORT" -lt 1 ] || [ "$OCTI_PORT" 
     exit 1
 fi
 
+# Resolve data directory
+OLD_DATA_DIR="/etc/octi-sync-server"
+NEW_DATA_DIR="/etc/octi-server"
+
+if [ -n "$OCTI_DATA_DIR" ]; then
+    DATA_DIR="$OCTI_DATA_DIR"
+    echo "Using data directory from OCTI_DATA_DIR: $DATA_DIR"
+elif mountpoint -q "$OLD_DATA_DIR" 2>/dev/null && mountpoint -q "$NEW_DATA_DIR" 2>/dev/null; then
+    echo "ERROR: Both $OLD_DATA_DIR and $NEW_DATA_DIR are mounted. Set OCTI_DATA_DIR to choose." >&2
+    exit 1
+elif mountpoint -q "$OLD_DATA_DIR" 2>/dev/null; then
+    echo "WARNING: $OLD_DATA_DIR is deprecated, please migrate your volume mount to $NEW_DATA_DIR" >&2
+    DATA_DIR="$OLD_DATA_DIR"
+else
+    DATA_DIR="$NEW_DATA_DIR"
+fi
+
 # Build command arguments
-CMD_ARGS="--datapath=/etc/octi-sync-server --port=$OCTI_PORT"
+CMD_ARGS="--datapath=$DATA_DIR --port=$OCTI_PORT"
 
 # Add debug flag if enabled
 if [ "$OCTI_DEBUG" = "true" ]; then
@@ -31,4 +49,4 @@ if [ "$OCTI_DEBUG" = "true" ]; then
 fi
 
 # Execute the application
-exec ./bin/octi-sync-server-kotlin $CMD_ARGS
+exec ./bin/octi-server $CMD_ARGS

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,4 +9,4 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
-rootProject.name = "octi-sync-server-kotlin"
+rootProject.name = "octi-server"


### PR DESCRIPTION
## Summary
- Rename all internal references from `octi-sync-server-kotlin` to `octi-server` to match the new repo name `d4rken-org/octi-server`
- Update Gradle project name, Dockerfile paths, CI workflow artifacts, README badge URLs, and IDE configs
- Add backward-compatible Docker volume detection: old mount path `/etc/octi-sync-server` is auto-detected via `mountpoint -q` with a deprecation warning
- Add `OCTI_DATA_DIR` env var to explicitly override the data directory
- Add Docker usage section to README with environment variables and migration note
