### PR TITLE
Restrict GITHUB_TOKEN permissions to minimum required

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 #v3
       with:
         java-version: '17'
         distribution: 'adopt'
@@ -14,7 +14,7 @@ runs:
       run: chmod +x gradlew
 
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3
       with:
         path: |
           ~/.gradle/wrapper
@@ -24,7 +24,7 @@ runs:
           ${{ runner.os }}-gradle-wrapper-
 
     - name: Cache Gradle Dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -6,13 +6,18 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-modules:
     name: Build apps
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        with:
+          persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
       - name: Build modules
@@ -24,7 +29,9 @@ jobs:
     container: ubuntu
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        with:
+          persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
       - name: Check code and run tests

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -8,10 +8,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        with:
+          persist-credentials: false
+      - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 #v1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   release-github:
     name: Create GitHub release
@@ -14,16 +16,17 @@ jobs:
     environment: foss-production
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
       - name: Get the version
         id: tagger
-        uses: jimschubert/query-tag-action@v2
+        uses: jimschubert/query-tag-action@ebe504c35d1ea44d7272c8eccc7a71e2e4f1b1cb #v2
         with:
           skip-unshallow: 'true'
           abbrev: false
@@ -37,7 +40,7 @@ jobs:
 
       - name: Create pre-release
         if: contains(steps.tagger.outputs.tag, '-beta')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 #v1
         with:
           prerelease: true
           tag_name: ${{ steps.tagger.outputs.tag }}
@@ -49,7 +52,7 @@ jobs:
 
       - name: Create release
         if: "!contains(steps.tagger.outputs.tag, '-beta')"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 #v1
         with:
           prerelease: false
           tag_name: ${{ steps.tagger.outputs.tag }}


### PR DESCRIPTION
Adds explicit permissions and persist-credentials: false to all three GitHub Actions workflows. Pins all external actions to commit SHAs.

Three changes per workflow:

1. **Top-level `permissions: contents: read`** (or `{}` for release) — Without an explicit permissions block, GITHUB_TOKEN inherits the repo default, which is typically read+write on all scopes. These workflows only need to check out code and run builds/tests. The release workflow's `release-github` job already declares `permissions: contents: write` at job level, which overrides the top-level default for that job only.

2. **`persist-credentials: false` on all `actions/checkout` steps** — By default, `actions/checkout` writes the GITHUB_TOKEN into `.git/config` as an authorization header, where it remains accessible to all subsequent steps in the job. No workflow in this repo needs `git push` after checkout, so there is no reason to leave credentials in the git config.

3. **Pin all external actions to commit SHAs** — Mutable version tags (`@v4`, `@v3`, `@v1`) can be re-tagged to point at different commits. Pinning to SHAs prevents supply-chain attacks via tag manipulation. Version comments (e.g., `#v4`) are preserved for readability.

No functional behavior changes.
