### PR TITLE
Concurrency hardening, commit rollback, and CI bumps

### DIFF
--- a/.claude/rules/build-commands.md
+++ b/.claude/rules/build-commands.md
@@ -52,7 +52,7 @@ Environment variables: `OCTI_PORT`, `OCTI_DEBUG`, `OCTI_DATA_DIR`
 
 - **code-checks.yml**: runs `assemble` + `check` on push to main and PRs
 - **release-tag.yml**: builds `installDist`, zips, creates GitHub release on `v*` tags
-- JDK 17 (adopt), Gradle 8.13
+- JDK 21 (temurin), Gradle 9.4.1
 
 ## Context Management
 

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -4,17 +4,17 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK 21
-      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 #v3
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
       with:
         java-version: '21'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Grant execute permission for gradlew
       shell: bash
       run: chmod +x gradlew
 
     - name: Cache Gradle Wrapper
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       with:
         path: |
           ~/.gradle/wrapper
@@ -24,7 +24,7 @@ runs:
           ${{ runner.os }}-gradle-wrapper-
 
     - name: Cache Gradle Dependencies
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
       - name: Setup project and build environment
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
       - name: Set up Docker Buildx
@@ -53,7 +53,7 @@ jobs:
       LC_ALL: C.UTF-8
     steps:
       - name: Checkout source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
       - name: Setup project and build environment
@@ -67,7 +67,7 @@ jobs:
     needs: [run-tests, build-docker-image]
     steps:
       - name: Checkout source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
       - name: Setup project and build environment

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -17,21 +17,13 @@ jobs:
     environment: foss-production
     steps:
       - name: Checkout source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
-
-      - name: Get the version
-        id: tagger
-        uses: jimschubert/query-tag-action@ebe504c35d1ea44d7272c8eccc7a71e2e4f1b1cb #v2
-        with:
-          skip-unshallow: 'true'
-          abbrev: false
-          commit-ish: HEAD
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a #v4.0.0
@@ -76,25 +68,12 @@ jobs:
       - name: Create ZIP file from the directory
         run: zip -r octi-server.zip ./build/install/octi-server
 
-      - name: Create pre-release
-        if: contains(steps.tagger.outputs.tag, '-')
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 #v1
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda #v3.0.0
         with:
-          prerelease: true
-          tag_name: ${{ steps.tagger.outputs.tag }}
-          name: ${{ steps.tagger.outputs.tag }}
-          generate_release_notes: true
-          files: octi-server.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create release
-        if: "!contains(steps.tagger.outputs.tag, '-')"
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 #v1
-        with:
-          prerelease: false
-          tag_name: ${{ steps.tagger.outputs.tag }}
-          name: ${{ steps.tagger.outputs.tag }}
+          prerelease: ${{ contains(github.ref_name, '-beta') }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           generate_release_notes: true
           files: octi-server.zip
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "2.3.10"
     application
-    id("com.google.devtools.ksp") version "2.3.5"
+    id("com.google.devtools.ksp") version "2.3.6"
     kotlin("plugin.serialization") version "2.3.10"
     id("io.ktor.plugin") version "3.4.0"
 }
@@ -14,8 +14,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.dagger:dagger:2.59.1")
-    ksp("com.google.dagger:dagger-compiler:2.59.1")
+    implementation("com.google.dagger:dagger:2.59.2")
+    ksp("com.google.dagger:dagger-compiler:2.59.2")
 
     val ktorVersion = "3.4.0"
     implementation("io.ktor:ktor-server-core:$ktorVersion")

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceRepo.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceRepo.kt
@@ -11,9 +11,12 @@ import eu.darken.octi.server.common.debug.logging.Logging.Priority.*
 import eu.darken.octi.server.common.debug.logging.asLog
 import eu.darken.octi.server.common.debug.logging.log
 import eu.darken.octi.server.common.debug.logging.logTag
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.io.IOException
 import java.time.Duration
@@ -36,6 +39,8 @@ class DeviceRepo @Inject constructor(
 
     private val devices = ConcurrentHashMap<DeviceKey, Device>()
     private val lastSeenPersistedAt = ConcurrentHashMap<DeviceKey, Instant>()
+    private val deletingDevices = mutableMapOf<DeviceKey, PendingDeviceDeletion>()
+    private val deletingDeviceIds = mutableMapOf<DeviceId, PendingDeviceDeletion>()
     private val mutex = Mutex()
 
     init {
@@ -108,6 +113,28 @@ class DeviceRepo @Inject constructor(
         path.resolve(DEVICE_FILENAME).writeText(serializer.encodeToString(data))
     }
 
+    private data class PendingDeviceDeletion(
+        val device: Device,
+        val completed: CompletableDeferred<Unit> = CompletableDeferred(),
+    )
+
+    private fun trackPendingDeletion(device: Device): PendingDeviceDeletion {
+        val pendingDeletion = PendingDeviceDeletion(device)
+        deletingDevices[device.key] = pendingDeletion
+        deletingDeviceIds[device.id] = pendingDeletion
+        return pendingDeletion
+    }
+
+    private suspend fun finishPendingDeletion(pendingDeletion: PendingDeviceDeletion) {
+        withContext(NonCancellable) {
+            mutex.withLock {
+                deletingDevices.remove(pendingDeletion.device.key, pendingDeletion)
+                deletingDeviceIds.remove(pendingDeletion.device.id, pendingDeletion)
+            }
+            pendingDeletion.completed.complete(Unit)
+        }
+    }
+
     suspend fun createDevice(
         account: Account,
         deviceId: DeviceId,
@@ -126,35 +153,43 @@ class DeviceRepo @Inject constructor(
             accountId = account.id,
             path = account.path.resolve("$DEVICES_DIR/${data.id}")
         )
-        mutex.withLock {
-            if (devices[device.key] != null) throw IllegalStateException("Device already exists: ${device.key}")
-            if (devices.values.any { it.id == device.id }) {
-                throw IllegalStateException("Device ID already registered to another account: ${device.id}")
-            }
-            // Count cap is enforced under the same mutex that registers the new device,
-            // so two concurrent creates can't both pass the check.
-            val currentDeviceCount = devices.values.count { it.accountId == account.id }
-            if (currentDeviceCount >= config.maxDevicesPerAccount) {
-                throw DeviceLimitExceededException(config.maxDevicesPerAccount)
-            }
+        while (true) {
+            val pendingDeletion = mutex.withLock {
+                val pendingDeletion = deletingDevices[device.key] ?: deletingDeviceIds[device.id]
+                if (pendingDeletion != null) {
+                    pendingDeletion
+                } else {
+                    if (devices[device.key] != null) throw IllegalStateException("Device already exists: ${device.key}")
+                    if (devices.values.any { it.id == device.id }) {
+                        throw IllegalStateException("Device ID already registered to another account: ${device.id}")
+                    }
+                    // Count cap is enforced under the same mutex that registers the new device,
+                    // so two concurrent creates can't both pass the check.
+                    val currentDeviceCount = devices.values.count { it.accountId == account.id }
+                    if (currentDeviceCount >= config.maxDevicesPerAccount) {
+                        throw DeviceLimitExceededException(config.maxDevicesPerAccount)
+                    }
 
-            device.path.run {
-                if (!parent.exists()) {
-                    parent.createDirectory()
-                    log(TAG) { "Created parent dir for $this" }
-                }
-                if (!exists()) {
-                    createDirectory()
-                    log(TAG) { "Created dir for $this" }
+                    device.path.run {
+                        if (!parent.exists()) {
+                            parent.createDirectory()
+                            log(TAG) { "Created parent dir for $this" }
+                        }
+                        if (!exists()) {
+                            createDirectory()
+                            log(TAG) { "Created dir for $this" }
+                        }
+                    }
+                    device.writeDevice()
+                    lastSeenPersistedAt[device.key] = device.lastSeen
+                    log(TAG, VERBOSE) { "Device written: $this" }
+                    devices[device.key] = device
+                    log(TAG) { "createDevice(): Device created $device" }
+                    return device
                 }
             }
-            device.writeDevice()
-            lastSeenPersistedAt[device.key] = device.lastSeen
-            log(TAG, VERBOSE) { "Device written: $this" }
-            devices[device.key] = device
+            pendingDeletion.completed.await()
         }
-        log(TAG) { "createDevice(): Device created $device" }
-        return device
     }
 
     suspend fun getDevice(key: DeviceKey): Device? {
@@ -177,48 +212,77 @@ class DeviceRepo @Inject constructor(
 
     suspend fun deleteDevice(key: DeviceKey) {
         log(TAG, VERBOSE) { "deleteDevice($key)..." }
-        val toDelete = mutex.withLock {
-            devices.remove(key).also { lastSeenPersistedAt.remove(key) } ?: throw IllegalArgumentException("$key not found")
+        val pendingDeletion = mutex.withLock {
+            val toDelete = devices.remove(key).also { lastSeenPersistedAt.remove(key) }
+                ?: throw IllegalArgumentException("$key not found")
+            trackPendingDeletion(toDelete)
         }
-        toDelete.sync.withLock {
-            toDelete.path.deleteRecursively()
-            log(TAG) { "deleteDevice($key): Device deleted: $toDelete" }
+        try {
+            pendingDeletion.device.sync.withLock {
+                val toDelete = pendingDeletion.device
+                toDelete.path.deleteRecursively()
+                log(TAG) { "deleteDevice($key): Device deleted: $toDelete" }
+            }
+        } finally {
+            finishPendingDeletion(pendingDeletion)
         }
     }
 
     suspend fun deleteDevices(accountId: AccountId) {
         log(TAG, VERBOSE) { "deleteDevices($accountId)..." }
-        val toDelete = mutex.withLock {
+        val pendingDeletions = mutex.withLock {
             devices
                 .filter { it.value.accountId == accountId }
                 .map {
                     lastSeenPersistedAt.remove(it.key)
-                    devices.remove(it.key)!!
+                    trackPendingDeletion(devices.remove(it.key)!!)
                 }
         }
-        log(TAG) { "deleteDevices($accountId): Deleting ${toDelete.size} devices" }
-        toDelete.forEach { device ->
-            device.sync.withLock {
-                device.path.deleteRecursively()
-                log(TAG) { "deleteDevices($accountId): Device deleted: $device" }
+        log(TAG) { "deleteDevices($accountId): Deleting ${pendingDeletions.size} devices" }
+        var firstFailure: Throwable? = null
+        pendingDeletions.forEach { pendingDeletion ->
+            try {
+                val device = pendingDeletion.device
+                device.sync.withLock {
+                    device.path.deleteRecursively()
+                    log(TAG) { "deleteDevices($accountId): Device deleted: $device" }
+                }
+            } catch (t: Throwable) {
+                if (firstFailure == null) {
+                    firstFailure = t
+                } else {
+                    firstFailure.addSuppressed(t)
+                }
+            } finally {
+                finishPendingDeletion(pendingDeletion)
             }
         }
+        firstFailure?.let { throw it }
     }
 
     suspend fun updateDevice(key: DeviceKey, action: (Device.Data) -> Device.Data) {
-        val device = devices[key] ?: return
+        val device = mutex.withLock { devices[key] } ?: return
         device.sync.withLock {
-            val newDevice = device.copy(data = action(device.data))
-            val oldWithoutLastSeen = device.data.copy(lastSeen = newDevice.lastSeen)
+            val current = mutex.withLock {
+                devices[key]?.takeIf { it.sync === device.sync }
+            } ?: return
+            val newDevice = current.copy(data = action(current.data))
+            val oldWithoutLastSeen = current.data.copy(lastSeen = newDevice.lastSeen)
             val metadataChanged = oldWithoutLastSeen != newDevice.data
-            val lastPersisted = lastSeenPersistedAt[key] ?: device.lastSeen
+            val lastPersisted = lastSeenPersistedAt[key] ?: current.lastSeen
             val shouldPersist = metadataChanged ||
                 Duration.between(lastPersisted, newDevice.lastSeen) >= LAST_SEEN_DEBOUNCE
             if (shouldPersist) {
                 newDevice.writeDevice()
-                lastSeenPersistedAt[key] = newDevice.lastSeen
             }
-            devices[key] = newDevice
+            mutex.withLock {
+                if (devices[key]?.sync === device.sync) {
+                    devices[key] = newDevice
+                    if (shouldPersist) {
+                        lastSeenPersistedAt[key] = newDevice.lastSeen
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/eu/darken/octi/server/module/ModuleLifecycleService.kt
+++ b/src/main/kotlin/eu/darken/octi/server/module/ModuleLifecycleService.kt
@@ -52,6 +52,12 @@ class ModuleLifecycleService @Inject constructor(
         data class EtagMismatch(val currentEtag: String) : DeleteBlobResult
     }
 
+    private data class ConsumedBlob(
+        val meta: UploadSessionMeta,
+        val liveBlobFile: Path,
+        val sessionDir: Path,
+    )
+
     /**
      * Legacy POST write — under device lock, loads old meta, rejects if blob-backed,
      * pre-checks the document quota delta, writes payload, settles quota, aborts
@@ -235,6 +241,24 @@ class ModuleLifecycleService @Inject constructor(
                 return@withLock CommitResult.QuotaExceeded to emptyList<Path>()
             }
             var rollbackDocDelta = docDelta > 0
+            var commitPointReached = false
+            val consumedBlobs = mutableListOf<ConsumedBlob>()
+
+            fun rollbackConsumedBlobs() {
+                if (consumedBlobs.isEmpty()) return
+                consumedBlobs.asReversed().forEach { consumed ->
+                    try {
+                        consumed.liveBlobFile.parent?.deleteRecursively()
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "commitModule: failed to rollback consumed blob ${consumed.liveBlobFile}: ${e.message}" }
+                    }
+                    sessionRepo.removeConsumedSession(consumed.meta.sessionId, consumed.sessionDir)
+                    if (consumed.meta.expectedSizeBytes > 0) {
+                        storageTracker.releaseReservation(caller.accountId, consumed.meta.expectedSizeBytes)
+                    }
+                }
+                consumedBlobs.clear()
+            }
 
             try {
                 val modulePath = moduleRepo.resolveModulePath(target, moduleId)
@@ -265,60 +289,54 @@ class ModuleLifecycleService @Inject constructor(
 
                 // Pass 2 — move staged blobs into live storage. peek+consume is TOCTOU
                 // (GC can terminate a peeked session before consume runs); on any failure
-                // here, roll back already-moved blobs by deleting their storageKey dirs.
+                // before module.json becomes the commit point, rollbackConsumedBlobs()
+                // deletes already-moved payloads and releases their reservations.
                 val newBlobRefs = mutableListOf<BlobRef>()
-                val movedDestPaths = mutableListOf<Path>()
-                fun rollbackMoves() {
-                    movedDestPaths.forEach { dest ->
-                        runCatching { dest.parent?.deleteRecursively() }
+                for (blobId in blobRefIds) {
+                    val existingRef = existingMeta?.blobRefs?.find { it.blobId == blobId }
+                    if (existingRef != null) {
+                        newBlobRefs.add(existingRef)
+                        continue
                     }
-                }
-                try {
-                    for (blobId in blobRefIds) {
-                        val existingRef = existingMeta?.blobRefs?.find { it.blobId == blobId }
-                        if (existingRef != null) {
-                            newBlobRefs.add(existingRef)
-                            continue
-                        }
-                        var capturedDest: Path? = null
-                        val consumed = sessionRepo.consumeAndMoveCompletedBlob(
-                            blobId = blobId,
-                            accountId = caller.accountId,
-                            deviceId = target.id,
-                            moduleId = moduleId,
-                        ) { meta ->
-                            val prefix = meta.storageKey.take(4)
-                            val destPath = modulePath.resolve("blobs").resolve(prefix).resolve(meta.storageKey).resolve("payload.blob")
-                            capturedDest = destPath
-                            destPath
-                        }
-                        val sessionMeta = when (consumed) {
-                            is UploadSessionRepo.ConsumeResult.Ready -> {
-                                capturedDest?.let { movedDestPaths.add(it) }
-                                consumed.meta
-                            }
-                            UploadSessionRepo.ConsumeResult.SessionNotFound -> {
-                                rollbackMoves()
-                                return@withLock CommitResult.BadRequest("Referenced blobId not found: $blobId") to emptyList<Path>()
-                            }
-                            UploadSessionRepo.ConsumeResult.PayloadMissing -> {
-                                rollbackMoves()
-                                return@withLock CommitResult.BadRequest("Staged blob payload missing for $blobId") to emptyList<Path>()
-                            }
-                        }
-                        newBlobRefs.add(
-                            BlobRef(
-                                blobId = sessionMeta.blobId,
-                                storageKey = sessionMeta.storageKey,
-                                sizeBytes = sessionMeta.expectedSizeBytes,
-                                hashAlgorithm = sessionMeta.hashAlgorithm,
-                                hashHex = sessionMeta.hashHex,
+                    var capturedDest: Path? = null
+                    val consumed = sessionRepo.consumeAndMoveCompletedBlob(
+                        blobId = blobId,
+                        accountId = caller.accountId,
+                        deviceId = target.id,
+                        moduleId = moduleId,
+                    ) { meta ->
+                        val prefix = meta.storageKey.take(4)
+                        val destPath = modulePath.resolve("blobs").resolve(prefix).resolve(meta.storageKey).resolve("payload.blob")
+                        capturedDest = destPath
+                        destPath
+                    }
+                    val sessionMeta = when (consumed) {
+                        is UploadSessionRepo.ConsumeResult.Ready -> {
+                            val liveBlobFile = capturedDest
+                                ?: throw IllegalStateException("Consumed blob destination was not captured")
+                            consumedBlobs.add(
+                                ConsumedBlob(
+                                    meta = consumed.meta,
+                                    liveBlobFile = liveBlobFile,
+                                    sessionDir = consumed.sessionDir,
+                                )
                             )
-                        )
+                            consumed.meta
+                        }
+                        UploadSessionRepo.ConsumeResult.SessionNotFound ->
+                            return@withLock CommitResult.BadRequest("Referenced blobId not found: $blobId") to emptyList<Path>()
+                        UploadSessionRepo.ConsumeResult.PayloadMissing ->
+                            return@withLock CommitResult.BadRequest("Staged blob payload missing for $blobId") to emptyList<Path>()
                     }
-                } catch (e: Exception) {
-                    rollbackMoves()
-                    throw e
+                    newBlobRefs.add(
+                        BlobRef(
+                            blobId = sessionMeta.blobId,
+                            storageKey = sessionMeta.storageKey,
+                            sizeBytes = sessionMeta.expectedSizeBytes,
+                            hashAlgorithm = sessionMeta.hashAlgorithm,
+                            hashHex = sessionMeta.hashHex,
+                        )
+                    )
                 }
 
                 // Write payload.blob first, then module.json as commit point
@@ -343,25 +361,29 @@ class ModuleLifecycleService @Inject constructor(
                 val tempMeta = modulePath.resolve("module.json.tmp")
                 tempMeta.writeText(json.encodeToString(meta))
                 tempMeta.moveTo(metaFile, overwrite = true)
+                commitPointReached = true
+                rollbackDocDelta = false
 
-                // Update access metadata
-                val accessFile = modulePath.resolve("access.json")
-                val tempAccess = modulePath.resolve("access.json.tmp")
-                tempAccess.writeText(json.encodeToString(AccessMeta(lastAccessedAt = now)))
-                tempAccess.moveTo(accessFile, overwrite = true)
+                // Update access metadata. module.json is the commit point; an access
+                // write failure must not turn a committed module into a quota rollback.
+                try {
+                    val accessFile = modulePath.resolve("access.json")
+                    val tempAccess = modulePath.resolve("access.json.tmp")
+                    tempAccess.writeText(json.encodeToString(AccessMeta(lastAccessedAt = now)))
+                    tempAccess.moveTo(accessFile, overwrite = true)
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "commitModule: failed to persist access metadata for $moduleId: ${e.message}" }
+                }
 
-                // Clean up committed sessions
-                for (ref in newBlobRefs) {
-                    if (existingMeta?.blobRefs?.any { it.blobId == ref.blobId } != true) {
-                        sessionRepo.removeCommittedSessionByBlobId(ref.blobId)
-                    }
+                // Clean up sessions whose payloads were consumed by this commit. Quota is
+                // settled below; this deletion deliberately does not release reservations.
+                for (consumed in consumedBlobs) {
+                    sessionRepo.removeConsumedSession(consumed.meta.sessionId, consumed.sessionDir)
                 }
 
                 // Quota update for blobs and shrinking documents. Positive doc delta was
                 // already applied by tryAdjustUsed above.
-                val newReferencedBytes = newBlobRefs.filter { ref ->
-                    existingMeta?.blobRefs?.any { it.blobId == ref.blobId } != true
-                }.sumOf { it.sizeBytes }
+                val newReferencedBytes = consumedBlobs.sumOf { it.meta.expectedSizeBytes }
                 val orphanedBlobRefs = existingMeta?.blobRefs
                     ?.filter { old -> newBlobRefs.none { it.blobId == old.blobId } }
                     ?: emptyList()
@@ -373,7 +395,6 @@ class ModuleLifecycleService @Inject constructor(
                 if (docDelta < 0) {
                     storageTracker.adjustUsed(caller.accountId, docDelta)
                 }
-                rollbackDocDelta = false
 
                 // Collect orphaned blob paths for async deletion outside the lock —
                 // deleting here would block every concurrent read/write for large orphans.
@@ -385,6 +406,9 @@ class ModuleLifecycleService @Inject constructor(
                 log(TAG) { "commitModule(${caller.id.shortId()}): $moduleId committed, etag=$newEtag" }
                 CommitResult.Success(newEtag) to orphansToDelete
             } finally {
+                if (!commitPointReached) {
+                    rollbackConsumedBlobs()
+                }
                 if (rollbackDocDelta) {
                     storageTracker.adjustUsed(caller.accountId, -docDelta)
                 }

--- a/src/main/kotlin/eu/darken/octi/server/module/UploadSessionRepo.kt
+++ b/src/main/kotlin/eu/darken/octi/server/module/UploadSessionRepo.kt
@@ -451,7 +451,7 @@ class UploadSessionRepo @Inject constructor(
     // region Lookups (scoped)
 
     sealed interface ConsumeResult {
-        data class Ready(val meta: UploadSessionMeta) : ConsumeResult
+        data class Ready(val meta: UploadSessionMeta, val sessionDir: Path) : ConsumeResult
         data object SessionNotFound : ConsumeResult
         data object PayloadMissing : ConsumeResult
     }
@@ -501,7 +501,7 @@ class UploadSessionRepo @Inject constructor(
             // cleans it up after the module.json rename. terminateSessionLocked sees the empty
             // session dir (staged file is gone) and skips releaseReservation — commitReservation
             // owns the reserved→used transition.
-            ConsumeResult.Ready(meta = current.meta)
+            ConsumeResult.Ready(meta = current.meta, sessionDir = current.sessionDir)
         }
     }
 
@@ -550,6 +550,21 @@ class UploadSessionRepo @Inject constructor(
         } catch (e: Exception) {
             log(TAG, WARN) { "removeCommittedSession: failed to clean up ${entry.key}: ${e.message}" }
         }
+    }
+
+    /**
+     * Drops a session whose staged payload has already been consumed by commit logic.
+     * Does not release quota; the caller owns the reserved -> used or reserved -> free
+     * transition after moving the staged payload out of the session directory.
+     */
+    fun removeConsumedSession(sessionId: String, sessionDir: Path) {
+        sessions.remove(sessionId)
+        try {
+            sessionDir.deleteRecursively()
+        } catch (e: Exception) {
+            log(TAG, WARN) { "removeConsumedSession: failed to clean up $sessionId: ${e.message}" }
+        }
+        cleanupEmptyParentsAfterSession(sessionDir)
     }
 
     /**

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceRepoTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceRepoTest.kt
@@ -9,8 +9,15 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldStartWith
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.io.path.exists
 
 class DeviceRepoTest : TestRunner() {
 
@@ -30,5 +37,228 @@ class DeviceRepoTest : TestRunner() {
             status shouldBe HttpStatusCode.NotFound
             bodyAsText() shouldStartWith "Unknown device"
         }
+    }
+
+    @Test
+    fun `concurrent updateDevice cannot resurrect deleted device`() = runTest2 {
+        val creds = createDevice()
+        val accountId = UUID.fromString(creds.account)
+        val key = DeviceKey(accountId, creds.deviceId)
+
+        val updateStarted = CountDownLatch(1)
+        val allowUpdateToFinish = CountDownLatch(1)
+        val updateError = AtomicReference<Throwable?>()
+        val deleteError = AtomicReference<Throwable?>()
+
+        val updateThread = thread(name = "device-update-race") {
+            try {
+                runBlocking {
+                    component.deviceRepo().updateDevice(key) { data ->
+                        updateStarted.countDown()
+                        if (!allowUpdateToFinish.await(5, TimeUnit.SECONDS)) {
+                            error("Timed out waiting to finish update")
+                        }
+                        data.copy(label = "updated")
+                    }
+                }
+            } catch (t: Throwable) {
+                updateError.set(t)
+            }
+        }
+
+        updateStarted.awaitOrFail("update did not start")
+
+        val deleteThread = thread(name = "device-delete-race") {
+            try {
+                runBlocking {
+                    component.deviceRepo().deleteDevice(key)
+                }
+            } catch (t: Throwable) {
+                deleteError.set(t)
+            }
+        }
+
+        Thread.sleep(100)
+        allowUpdateToFinish.countDown()
+        updateThread.joinOrFail(updateError)
+        deleteThread.joinOrFail(deleteError)
+
+        component.deviceRepo().getDevice(key) shouldBe null
+        getDevicePath(creds).exists() shouldBe false
+    }
+
+    @Test
+    fun `concurrent updateDevice cannot resurrect bulk-deleted device`() = runTest2 {
+        val creds = createDevice()
+        val accountId = UUID.fromString(creds.account)
+        val key = DeviceKey(accountId, creds.deviceId)
+
+        val updateStarted = CountDownLatch(1)
+        val allowUpdateToFinish = CountDownLatch(1)
+        val updateError = AtomicReference<Throwable?>()
+        val deleteError = AtomicReference<Throwable?>()
+
+        val updateThread = thread(name = "device-update-bulk-race") {
+            try {
+                runBlocking {
+                    component.deviceRepo().updateDevice(key) { data ->
+                        updateStarted.countDown()
+                        if (!allowUpdateToFinish.await(5, TimeUnit.SECONDS)) {
+                            error("Timed out waiting to finish update")
+                        }
+                        data.copy(label = "updated")
+                    }
+                }
+            } catch (t: Throwable) {
+                updateError.set(t)
+            }
+        }
+
+        updateStarted.awaitOrFail("update did not start")
+
+        val deleteThread = thread(name = "device-delete-bulk-race") {
+            try {
+                runBlocking {
+                    component.deviceRepo().deleteDevices(accountId)
+                }
+            } catch (t: Throwable) {
+                deleteError.set(t)
+            }
+        }
+
+        Thread.sleep(100)
+        allowUpdateToFinish.countDown()
+        updateThread.joinOrFail(updateError)
+        deleteThread.joinOrFail(deleteError)
+
+        component.deviceRepo().getDevice(key) shouldBe null
+        getDevicePath(creds).exists() shouldBe false
+    }
+
+    @Test
+    fun `blocked updateDevice for one device does not block unrelated device updates`() = runTest2 {
+        val creds1 = createDevice()
+        val creds2 = createDevice(creds1)
+        val accountId = UUID.fromString(creds1.account)
+        val key1 = DeviceKey(accountId, creds1.deviceId)
+        val key2 = DeviceKey(accountId, creds2.deviceId)
+        val repo = component.deviceRepo()
+        val device1 = repo.getDevice(key1)!!
+
+        val blockedUpdateError = AtomicReference<Throwable?>()
+        val otherUpdateError = AtomicReference<Throwable?>()
+        var otherUpdateThread: Thread? = null
+        var otherUpdateCompletedPromptly = false
+
+        device1.sync.lock()
+        val blockedUpdateThread = thread(name = "device-update-blocked-on-sync") {
+            try {
+                runBlocking {
+                    repo.updateDevice(key1) { data ->
+                        data.copy(label = "blocked update finished")
+                    }
+                }
+            } catch (t: Throwable) {
+                blockedUpdateError.set(t)
+            }
+        }
+
+        try {
+            Thread.sleep(250)
+            otherUpdateThread = thread(name = "device-update-unrelated") {
+                try {
+                    runBlocking {
+                        repo.updateDevice(key2) { data ->
+                            data.copy(label = "unrelated update finished")
+                        }
+                    }
+                } catch (t: Throwable) {
+                    otherUpdateError.set(t)
+                }
+            }
+            otherUpdateThread.join(1_000)
+            otherUpdateCompletedPromptly = !otherUpdateThread.isAlive
+        } finally {
+            device1.sync.unlock()
+        }
+
+        blockedUpdateThread.joinOrFail(blockedUpdateError)
+        otherUpdateThread.joinOrFail(otherUpdateError)
+        otherUpdateCompletedPromptly shouldBe true
+        repo.getDevice(key1)!!.label shouldBe "blocked update finished"
+        repo.getDevice(key2)!!.label shouldBe "unrelated update finished"
+    }
+
+    @Test
+    fun `deleteDevice waiting on one device sync does not block unrelated device updates`() = runTest2 {
+        val creds1 = createDevice()
+        val creds2 = createDevice(creds1)
+        val accountId = UUID.fromString(creds1.account)
+        val key1 = DeviceKey(accountId, creds1.deviceId)
+        val key2 = DeviceKey(accountId, creds2.deviceId)
+        val repo = component.deviceRepo()
+        val device1 = repo.getDevice(key1)!!
+
+        val deleteError = AtomicReference<Throwable?>()
+        val otherUpdateError = AtomicReference<Throwable?>()
+        var otherUpdateThread: Thread? = null
+        var otherUpdateCompletedPromptly = false
+
+        device1.sync.lock()
+        val deleteThread = thread(name = "device-delete-blocked-on-sync") {
+            try {
+                runBlocking {
+                    repo.deleteDevice(key1)
+                }
+            } catch (t: Throwable) {
+                deleteError.set(t)
+            }
+        }
+
+        try {
+            waitUntilOrFail("delete did not remove the device from memory") {
+                runBlocking { repo.getDevice(key1) == null }
+            }
+            otherUpdateThread = thread(name = "device-update-while-delete-blocked") {
+                try {
+                    runBlocking {
+                        repo.updateDevice(key2) { data ->
+                            data.copy(label = "updated while delete blocked")
+                        }
+                    }
+                } catch (t: Throwable) {
+                    otherUpdateError.set(t)
+                }
+            }
+            otherUpdateThread.join(1_000)
+            otherUpdateCompletedPromptly = !otherUpdateThread.isAlive
+        } finally {
+            device1.sync.unlock()
+        }
+
+        deleteThread.joinOrFail(deleteError)
+        otherUpdateThread.joinOrFail(otherUpdateError)
+        otherUpdateCompletedPromptly shouldBe true
+        repo.getDevice(key1) shouldBe null
+        repo.getDevice(key2)!!.label shouldBe "updated while delete blocked"
+        getDevicePath(creds1).exists() shouldBe false
+    }
+
+    private fun CountDownLatch.awaitOrFail(message: String) {
+        if (!await(5, TimeUnit.SECONDS)) throw AssertionError(message)
+    }
+
+    private fun waitUntilOrFail(message: String, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (!condition()) {
+            if (System.currentTimeMillis() >= deadline) throw AssertionError(message)
+            Thread.sleep(10)
+        }
+    }
+
+    private fun Thread.joinOrFail(error: AtomicReference<Throwable?>) {
+        join(5_000)
+        isAlive shouldBe false
+        error.get()?.let { throw AssertionError("Thread failed", it) }
     }
 }

--- a/src/test/kotlin/eu/darken/octi/server/module/BlobQuotaBoundaryFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/module/BlobQuotaBoundaryFlowTest.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
 import java.util.*
+import kotlin.io.path.createDirectories
 
 private fun base64Encode(data: ByteArray): String = Base64.getEncoder().encodeToString(data)
 
@@ -25,6 +26,39 @@ class BlobQuotaBoundaryFlowTest : TestRunner() {
         val blobId: String = "",
         val sessionId: String = "",
     )
+
+    private suspend fun TestEnvironment.createFinalizedSession(
+        creds: Credentials,
+        moduleId: String,
+        payload: ByteArray,
+    ): SessionInfo {
+        val hash = payload.sha256Hex()
+        val session = http.post("/v1/module/$moduleId/blob-sessions") {
+            url { parameters.append("device-id", creds.deviceId.toString()) }
+            addCredentials(creds)
+            contentType(ContentType.Application.Json)
+            setBody("""{"sizeBytes": ${payload.size}, "hashAlgorithm": "sha256", "hashHex": "$hash"}""")
+        }.body<SessionInfo>()
+
+        if (payload.isNotEmpty()) {
+            http.patch("/v1/module/$moduleId/blob-sessions/${session.sessionId}") {
+                url { parameters.append("device-id", creds.deviceId.toString()) }
+                addCredentials(creds)
+                header("Upload-Offset", "0")
+                contentType(ContentType.Application.OctetStream)
+                setBody(payload)
+            }.status shouldBe HttpStatusCode.NoContent
+        }
+
+        http.post("/v1/module/$moduleId/blob-sessions/${session.sessionId}/finalize") {
+            url { parameters.append("device-id", creds.deviceId.toString()) }
+            addCredentials(creds)
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }.status shouldBe HttpStatusCode.OK
+
+        return session
+    }
 
     @Test
     fun `session at exact quota succeeds, one more byte returns 507`() {
@@ -73,6 +107,40 @@ class BlobQuotaBoundaryFlowTest : TestRunner() {
                 setBody("""{"sizeBytes": 1024}""")
             }
             second.status shouldBe HttpStatusCode.Created
+        }
+    }
+
+    @Test
+    fun `failed PUT after consuming blob releases reservation`() {
+        runTest2(appConfig = baseConfig.copy(accountQuotaBytes = 1024, maxBlobBytes = 10_000)) {
+            val creds = createDevice()
+            val accountId = UUID.fromString(creds.account)
+            val failingModuleId = "eu.darken.octi.quota.failedput"
+            val payload = ByteArray(1024) { 7 }
+            val session = createFinalizedSession(creds, failingModuleId, payload)
+
+            component.storageTracker().getUsage(accountId).reservedBytes shouldBe 1024
+
+            val moduleDir = BlobFixtures.moduleDir(config.dataPath, accountId, creds.deviceId, failingModuleId)
+            moduleDir.resolve("module.json.tmp").createDirectories()
+
+            http.put("/v1/module/$failingModuleId") {
+                url { parameters.append("device-id", creds.deviceId.toString()) }
+                addCredentials(creds)
+                header("If-None-Match", "*")
+                contentType(ContentType.Application.Json)
+                setBody("""{"documentBase64": "${base64Encode(ByteArray(0))}", "blobRefs": [{"blobId": "${session.blobId}"}]}""")
+            }.status shouldBe HttpStatusCode.InternalServerError
+
+            component.storageTracker().getUsage(accountId).reservedBytes shouldBe 0
+            component.sessionRepo().getSession(session.sessionId, accountId, creds.deviceId, failingModuleId) shouldBe null
+
+            http.post("/v1/module/eu.darken.octi.quota.retry/blob-sessions") {
+                url { parameters.append("device-id", creds.deviceId.toString()) }
+                addCredentials(creds)
+                contentType(ContentType.Application.Json)
+                setBody("""{"sizeBytes": 1024}""")
+            }.status shouldBe HttpStatusCode.Created
         }
     }
 


### PR DESCRIPTION
## Summary

- **Prevent device resurrection without serializing auth** — concurrent `updateDevice` + `deleteDevice` could resurrect a deleted device because per-device sync was acquired without coordinating against the global devices map. Holding the global mutex through file I/O would have stalled all auth on the server behind any slow per-device operation. New design holds the global mutex only for short critical sections (map ops, identity-pinned commit) and uses per-instance reference equality + a `PendingDeviceDeletion` tracker (`CompletableDeferred` indexed by both `DeviceKey` and `DeviceId`) to gate `createDevice` against in-flight path deletions.
- **Roll back consumed blobs and quota on commit failure** — old `rollbackMoves()` only unlinked moved blob files; it didn't release reservations or remove the upload sessions whose payloads had been consumed. A commit that failed after `consumeAndMoveCompletedBlob` (e.g. module.json rename throws) leaked `reservedBytes` and orphan sessions. `commitModule` now tracks each consumed blob explicitly and rolls back payload + session + reservation before the module.json rename. After the rename (the commit point), an `access.json` failure is logged-and-swallowed.
- **CI maintenance** — action pin bumps (`checkout` v6.0.2, `setup-java` v5.2.0, `cache` v5.0.3, `action-gh-release` v3), JDK distribution `adopt` → `temurin` (Adoptium rebrand), drop `jimschubert/query-tag-action` in favor of `github.ref_name`, collapse dual release-tag steps with conditional prerelease (`-beta` only — intentional), KSP 2.3.5 → 2.3.6, Dagger 2.59.1 → 2.59.2.

## Test plan

- [x] `./gradlew check` passes locally (5m 40s)
- [x] `DeviceRepoTest` — 4 tests: 2 resurrection-prevention + 2 no-head-of-line-blocking
- [x] `BlobQuotaBoundaryFlowTest.failed PUT after consuming blob releases reservation`
- [ ] CI green: `code-checks.yml` (assemble, check, Docker build, cross-version regression replay)
- [ ] Next tag cut produces a release with the simplified conditional prerelease step (no functional difference for non-`-beta` tags)
