### PR TITLE
feat: add periodic device activity reporter

### DIFF
--- a/src/main/kotlin/eu/darken/octi/server/App.kt
+++ b/src/main/kotlin/eu/darken/octi/server/App.kt
@@ -9,6 +9,7 @@ import eu.darken.octi.server.common.debug.logging.Logging.Priority.*
 import eu.darken.octi.server.common.debug.logging.log
 import eu.darken.octi.server.common.debug.logging.logTag
 import eu.darken.octi.server.common.debug.DebugFlagMonitor
+import eu.darken.octi.server.device.DeviceActivityReporter
 import eu.darken.octi.server.module.StartupRecoveryService
 import eu.darken.octi.server.module.UploadSessionRepo
 import java.nio.file.Path
@@ -26,6 +27,7 @@ class App @Inject constructor(
     private val sessionRepo: UploadSessionRepo,
     private val diskSpaceProbe: DiskSpaceProbe,
     @Suppress("unused") private val debugFlagMonitor: DebugFlagMonitor,
+    @Suppress("unused") private val deviceActivityReporter: DeviceActivityReporter,
 ) {
 
     fun launch() {

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceActivityReporter.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceActivityReporter.kt
@@ -1,0 +1,138 @@
+package eu.darken.octi.server.device
+
+import eu.darken.octi.server.common.AppScope
+import eu.darken.octi.server.common.debug.logging.Logging.Priority.INFO
+import eu.darken.octi.server.common.debug.logging.log
+import eu.darken.octi.server.common.debug.logging.logTag
+import eu.darken.octi.server.common.launchPeriodicJob
+import eu.darken.octi.server.ws.ConnectionRegistry
+import java.time.Duration
+import java.time.Instant
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DeviceActivityReporter @Inject constructor(
+    appScope: AppScope,
+    private val deviceRepo: DeviceRepo,
+    private val connectionRegistry: ConnectionRegistry,
+) {
+
+    data class Report(
+        val oneHour: WindowStats,
+        val twentyFourHours: WindowStats,
+    )
+
+    data class WindowStats(
+        val label: String,
+        val total: Int,
+        val versions: List<VersionStats>,
+    )
+
+    data class VersionStats(
+        val version: String,
+        val count: Int,
+        val percent: Double,
+    )
+
+    init {
+        appScope.launchPeriodicJob(
+            tag = TAG,
+            interval = REPORT_INTERVAL,
+            initialDelay = REPORT_INTERVAL,
+            onErrorMessage = "Device activity report failed",
+        ) {
+            logReport()
+        }
+    }
+
+    internal fun logReport(now: Instant = Instant.now()) {
+        val report = buildReport(
+            devices = deviceRepo.allDevices(),
+            activeDeviceKeys = connectionRegistry.activeDeviceKeys(),
+            now = now,
+        )
+        log(TAG, INFO) { formatReport(report) }
+    }
+
+    companion object {
+        private val REPORT_INTERVAL: Duration = Duration.ofMinutes(5)
+        private val ONE_HOUR: Duration = Duration.ofHours(1)
+        private val TWENTY_FOUR_HOURS: Duration = Duration.ofHours(24)
+        private const val UNKNOWN_VERSION = "<unknown>"
+        private const val MAX_VERSION_DISPLAY_LENGTH = 80
+        private val CONTROL_CHARS = Regex("[\\p{Cntrl}]+")
+        private val TAG = logTag("Device", "Activity")
+
+        internal fun buildReport(
+            devices: Collection<Device>,
+            activeDeviceKeys: Set<DeviceKey>,
+            now: Instant = Instant.now(),
+        ): Report = Report(
+            oneHour = buildWindowStats("1h", ONE_HOUR, devices, activeDeviceKeys, now),
+            twentyFourHours = buildWindowStats("24h", TWENTY_FOUR_HOURS, devices, activeDeviceKeys, now),
+        )
+
+        internal fun formatReport(report: Report): String {
+            return "device-stats: ${formatWindow(report.oneHour)}; ${formatWindow(report.twentyFourHours)}"
+        }
+
+        internal fun sanitizeVersionForLog(raw: String?): String {
+            val sanitized = raw
+                ?.replace(CONTROL_CHARS, " ")
+                ?.trim()
+                ?.ifBlank { null }
+                ?: return UNKNOWN_VERSION
+
+            return if (sanitized.length <= MAX_VERSION_DISPLAY_LENGTH) {
+                sanitized
+            } else {
+                sanitized.take(MAX_VERSION_DISPLAY_LENGTH - 3) + "..."
+            }
+        }
+
+        private fun buildWindowStats(
+            label: String,
+            window: Duration,
+            devices: Collection<Device>,
+            activeDeviceKeys: Set<DeviceKey>,
+            now: Instant,
+        ): WindowStats {
+            val cutoff = now.minus(window)
+            val activeDevices = devices.filter { device ->
+                !device.lastSeen.isBefore(cutoff) || device.key in activeDeviceKeys
+            }
+
+            val versionCounts = activeDevices
+                .groupingBy { sanitizeVersionForLog(it.version) }
+                .eachCount()
+
+            val total = activeDevices.size
+            val versions = versionCounts.entries
+                .map { (version, count) ->
+                    VersionStats(
+                        version = version,
+                        count = count,
+                        percent = if (total == 0) 0.0 else count * 100.0 / total,
+                    )
+                }
+                .sortedWith(compareByDescending<VersionStats> { it.count }.thenBy { it.version })
+
+            return WindowStats(
+                label = label,
+                total = total,
+                versions = versions,
+            )
+        }
+
+        private fun formatWindow(stats: WindowStats): String {
+            val versions = stats.versions.joinToString(prefix = "[", postfix = "]") {
+                "${it.version}=${it.count} (${formatPercent(it.percent)}%)"
+            }
+            return "${stats.label} total=${stats.total} versions=$versions"
+        }
+
+        private fun formatPercent(percent: Double): String = String.format(Locale.US, "%.1f", percent)
+    }
+}

--- a/src/main/kotlin/eu/darken/octi/server/ws/ConnectionRegistry.kt
+++ b/src/main/kotlin/eu/darken/octi/server/ws/ConnectionRegistry.kt
@@ -128,6 +128,8 @@ class ConnectionRegistry(
         return sessions.values.filter { it.accountId == accountId && it.deviceId != excludeDevice }
     }
 
+    fun activeDeviceKeys(): Set<DeviceKey> = sessions.keys.toSet()
+
     fun stats(): Stats = Stats(
         totalDevices = sessions.size,
         totalAccounts = sessions.values.map { it.accountId }.distinct().size,

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceActivityReporterTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceActivityReporterTest.kt
@@ -1,0 +1,146 @@
+package eu.darken.octi.server.device
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+class DeviceActivityReporterTest {
+
+    private val now: Instant = Instant.parse("2026-04-29T12:00:00Z")
+
+    @Test
+    fun `report counts lastSeen windows and currently connected devices`() {
+        val oneHour = device(version = "octi/1.0.0", lastSeen = now.minus(Duration.ofMinutes(10)))
+        val twentyFourHours = device(version = "octi/2.0.0", lastSeen = now.minus(Duration.ofHours(2)))
+        val connected = device(version = "octi/3.0.0", lastSeen = now.minus(Duration.ofHours(30)))
+        val inactive = device(version = "octi/4.0.0", lastSeen = now.minus(Duration.ofHours(30)))
+
+        val report = DeviceActivityReporter.buildReport(
+            devices = listOf(oneHour, twentyFourHours, connected, inactive),
+            activeDeviceKeys = setOf(connected.key),
+            now = now,
+        )
+
+        report.oneHour.total shouldBe 2
+        report.oneHour.versionCounts() shouldBe mapOf(
+            "octi/1.0.0" to 1,
+            "octi/3.0.0" to 1,
+        )
+
+        report.twentyFourHours.total shouldBe 3
+        report.twentyFourHours.versionCounts() shouldBe mapOf(
+            "octi/1.0.0" to 1,
+            "octi/2.0.0" to 1,
+            "octi/3.0.0" to 1,
+        )
+    }
+
+    @Test
+    fun `report formats counts and percentages sorted by count`() {
+        val report = DeviceActivityReporter.buildReport(
+            devices = listOf(
+                device(version = "octi/1.0.0", lastSeen = now),
+                device(version = "octi/1.0.0", lastSeen = now),
+                device(version = "octi/2.0.0", lastSeen = now),
+            ),
+            activeDeviceKeys = emptySet(),
+            now = now,
+        )
+
+        DeviceActivityReporter.formatReport(report) shouldBe
+            "device-stats: 1h total=3 versions=[octi/1.0.0=2 (66.7%), octi/2.0.0=1 (33.3%)]; " +
+            "24h total=3 versions=[octi/1.0.0=2 (66.7%), octi/2.0.0=1 (33.3%)]"
+    }
+
+    @Test
+    fun `unknown versions are grouped and empty windows are safe`() {
+        val empty = DeviceActivityReporter.buildReport(
+            devices = emptyList(),
+            activeDeviceKeys = emptySet(),
+            now = now,
+        )
+        empty.oneHour.total shouldBe 0
+        empty.oneHour.versions shouldBe emptyList()
+
+        val report = DeviceActivityReporter.buildReport(
+            devices = listOf(
+                device(version = null, lastSeen = now),
+                device(version = "   ", lastSeen = now),
+            ),
+            activeDeviceKeys = emptySet(),
+            now = now,
+        )
+
+        report.oneHour.versions shouldBe listOf(
+            DeviceActivityReporter.VersionStats(
+                version = "<unknown>",
+                count = 2,
+                percent = 100.0,
+            )
+        )
+    }
+
+    @Test
+    fun `sanitized-equivalent versions are grouped together`() {
+        val report = DeviceActivityReporter.buildReport(
+            devices = listOf(
+                device(version = "octi/1.0.0", lastSeen = now),
+                device(version = "  octi/1.0.0  ", lastSeen = now),
+                device(version = null, lastSeen = now),
+                device(version = "\n\t", lastSeen = now),
+            ),
+            activeDeviceKeys = emptySet(),
+            now = now,
+        )
+
+        report.oneHour.versions shouldBe listOf(
+            DeviceActivityReporter.VersionStats(
+                version = "<unknown>",
+                count = 2,
+                percent = 50.0,
+            ),
+            DeviceActivityReporter.VersionStats(
+                version = "octi/1.0.0",
+                count = 2,
+                percent = 50.0,
+            ),
+        )
+    }
+
+    @Test
+    fun `version display is sanitized for logs`() {
+        DeviceActivityReporter.sanitizeVersionForLog("  octi\n1\t  ") shouldBe "octi 1"
+
+        val longVersion = "v" + "a".repeat(100)
+        val sanitized = DeviceActivityReporter.sanitizeVersionForLog(longVersion)
+
+        sanitized.length shouldBe 80
+        sanitized.endsWith("...") shouldBe true
+    }
+
+    private fun DeviceActivityReporter.WindowStats.versionCounts(): Map<String, Int> {
+        return versions.associate { it.version to it.count }
+    }
+
+    private fun device(
+        version: String?,
+        lastSeen: Instant,
+        accountId: UUID = UUID.randomUUID(),
+        deviceId: UUID = UUID.randomUUID(),
+    ): Device {
+        return Device(
+            data = Device.Data(
+                id = deviceId,
+                password = "test-password",
+                version = version,
+                addedAt = lastSeen,
+                lastSeen = lastSeen,
+            ),
+            path = Path.of("/tmp/$deviceId"),
+            accountId = accountId,
+        )
+    }
+}

--- a/src/test/kotlin/eu/darken/octi/server/ws/ConnectionRegistryTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/ws/ConnectionRegistryTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.server.ws
 
 import eu.darken.octi.server.common.AppScope
+import eu.darken.octi.server.device.DeviceKey
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -114,6 +115,21 @@ class ConnectionRegistryTest {
 
         registerDevice(device3, accountB)
         registry.stats() shouldBe ConnectionRegistry.Stats(totalDevices = 3, totalAccounts = 2)
+    }
+
+    @Test
+    fun `activeDeviceKeys returns connected device snapshot`() = runBlocking {
+        val session = registerDevice(device1, accountA)
+        registerDevice(device2, accountA)
+
+        registry.activeDeviceKeys() shouldBe setOf(
+            DeviceKey(accountA, device1),
+            DeviceKey(accountA, device2),
+        )
+
+        registry.unregister(session)
+
+        registry.activeDeviceKeys() shouldBe setOf(DeviceKey(accountA, device2))
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Add `DeviceActivityReporter` background job that logs active-device counts grouped by client version every 5 minutes, with both 1h and 24h windows.
- Active = device with `lastSeen` within the window OR a live WebSocket connection. New `ConnectionRegistry.activeDeviceKeys()` snapshot exposes the latter.
- Reporter is wired through Dagger; `App` constructs it eagerly so the periodic job starts at boot.

## Test plan
- [x] `DeviceActivityReporterTest` — window membership, format/percent, unknown bucket, sanitizer truncation, sanitized-equivalent grouping
- [x] `ConnectionRegistryTest` — `activeDeviceKeys` snapshot on register/unregister
- [ ] After deploy, confirm `device-stats: 1h total=… 24h total=…` shows up in operator logs