### PR TITLE
feat: log per-minute sync notification stats

### DIFF
--- a/src/main/kotlin/eu/darken/octi/server/ws/SyncNotificationStats.kt
+++ b/src/main/kotlin/eu/darken/octi/server/ws/SyncNotificationStats.kt
@@ -1,0 +1,133 @@
+package eu.darken.octi.server.ws
+
+import java.time.Duration
+
+internal class SyncNotificationStats {
+
+    data class Snapshot(
+        val batches: Long,
+        val events: Long,
+        val deliveredPayloads: Long,
+        val deliveredEvents: Long,
+        val skippedSelfPeers: Long,
+        val noPeers: Long,
+        val closedSessions: Long,
+        val bufferFullDrops: Long,
+        val failures: Long,
+        val moduleCounts: Map<String, Long>,
+    ) {
+        fun format(window: Duration): String {
+            val modules = moduleCounts.entries
+                .sortedWith(compareByDescending<Map.Entry<String, Long>> { it.value }.thenBy { it.key })
+                .joinToString(prefix = "[", postfix = "]") { "${it.key}=${it.value}" }
+
+            return "sync-stats: ${window.toCompactString()} batches=$batches events=$events " +
+                "deliveredPayloads=$deliveredPayloads deliveredEvents=$deliveredEvents " +
+                "skippedSelfPeers=$skippedSelfPeers noPeers=$noPeers " +
+                "closedSessions=$closedSessions bufferFullDrops=$bufferFullDrops failures=$failures " +
+                "modules=$modules"
+        }
+    }
+
+    private val lock = Any()
+    private var batches = 0L
+    private var events = 0L
+    private var deliveredPayloads = 0L
+    private var deliveredEvents = 0L
+    private var skippedSelfPeers = 0L
+    private var noPeers = 0L
+    private var closedSessions = 0L
+    private var bufferFullDrops = 0L
+    private var failures = 0L
+    private val moduleCounts = mutableMapOf<String, Long>()
+
+    fun recordBatch(events: List<SyncNotifier.EventPayload.Event>) = synchronized(lock) {
+        batches += 1
+        this.events += events.size.toLong()
+        events.forEach { event ->
+            when (event) {
+                is SyncNotifier.EventPayload.Event.ModuleChanged -> {
+                    moduleCounts[event.moduleId] = (moduleCounts[event.moduleId] ?: 0L) + 1L
+                }
+            }
+        }
+    }
+
+    fun recordDelivery(eventCount: Int) = synchronized(lock) {
+        deliveredPayloads += 1
+        deliveredEvents += eventCount.toLong()
+    }
+
+    fun recordSkippedSelfPeer() = synchronized(lock) {
+        skippedSelfPeers += 1
+    }
+
+    fun recordNoPeers() = synchronized(lock) {
+        noPeers += 1
+    }
+
+    fun recordClosedSession() = synchronized(lock) {
+        closedSessions += 1
+    }
+
+    fun recordBufferFullDrop() = synchronized(lock) {
+        bufferFullDrops += 1
+    }
+
+    fun recordFailure() = synchronized(lock) {
+        failures += 1
+    }
+
+    fun snapshotAndReset(): Snapshot? = synchronized(lock) {
+        if (isEmpty()) return@synchronized null
+
+        Snapshot(
+            batches = batches,
+            events = events,
+            deliveredPayloads = deliveredPayloads,
+            deliveredEvents = deliveredEvents,
+            skippedSelfPeers = skippedSelfPeers,
+            noPeers = noPeers,
+            closedSessions = closedSessions,
+            bufferFullDrops = bufferFullDrops,
+            failures = failures,
+            moduleCounts = moduleCounts.toMap(),
+        ).also {
+            reset()
+        }
+    }
+
+    private fun isEmpty(): Boolean =
+        batches == 0L &&
+            events == 0L &&
+            deliveredPayloads == 0L &&
+            deliveredEvents == 0L &&
+            skippedSelfPeers == 0L &&
+            noPeers == 0L &&
+            closedSessions == 0L &&
+            bufferFullDrops == 0L &&
+            failures == 0L &&
+            moduleCounts.isEmpty()
+
+    private fun reset() {
+        batches = 0L
+        events = 0L
+        deliveredPayloads = 0L
+        deliveredEvents = 0L
+        skippedSelfPeers = 0L
+        noPeers = 0L
+        closedSessions = 0L
+        bufferFullDrops = 0L
+        failures = 0L
+        moduleCounts.clear()
+    }
+}
+
+private fun Duration.toCompactString(): String {
+    val seconds = toSeconds()
+    return when {
+        seconds % 3600L == 0L -> "${seconds / 3600L}h"
+        seconds % 60L == 0L -> "${seconds / 60L}m"
+        else -> "${seconds}s"
+    }
+}

--- a/src/main/kotlin/eu/darken/octi/server/ws/SyncNotifier.kt
+++ b/src/main/kotlin/eu/darken/octi/server/ws/SyncNotifier.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.server.ws
 
 import eu.darken.octi.server.account.AccountId
 import eu.darken.octi.server.common.AppScope
+import eu.darken.octi.server.common.launchPeriodicJob
 import eu.darken.octi.server.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.server.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.server.common.debug.logging.Logging.Priority.WARN
@@ -17,6 +18,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -56,6 +58,20 @@ class SyncNotifier @Inject constructor(
 
     private val lock = Mutex()
     private val pending = mutableMapOf<AccountId, PendingBroadcast>()
+    private val stats = SyncNotificationStats()
+
+    init {
+        appScope.launchPeriodicJob(
+            tag = TAG,
+            interval = STATS_INTERVAL,
+            initialDelay = STATS_INTERVAL,
+            onErrorMessage = "Sync notification stats reporting failed",
+        ) {
+            stats.snapshotAndReset()?.let { snapshot ->
+                log(TAG, INFO) { snapshot.format(STATS_INTERVAL) }
+            }
+        }
+    }
 
     suspend fun enqueueModuleChanged(
         accountId: AccountId,
@@ -98,16 +114,18 @@ class SyncNotifier @Inject constructor(
             val broadcast = lock.withLock {
                 pending.remove(accountId)
             } ?: return@launch
+            stats.recordBatch(broadcast.events)
 
             val allPeers = connectionRegistry.getAccountSessions(accountId)
 
             if (allPeers.isEmpty()) {
+                stats.recordNoPeers()
                 log(TAG, VERBOSE) { "broadcast(): No peers for account=$accountId, dropping ${broadcast.events.size} events" }
                 return@launch
             }
 
             val moduleIds = broadcast.events.joinToString { (it as? EventPayload.Event.ModuleChanged)?.moduleId ?: "?" }
-            log(TAG, INFO) { "broadcast(): Sending [$moduleIds] to account=$accountId" }
+            log(TAG) { "broadcast(): Sending [$moduleIds] to account=$accountId" }
 
             allPeers.forEach { peer ->
                 val peerDeviceIdStr = peer.deviceId.toString()
@@ -121,6 +139,7 @@ class SyncNotifier @Inject constructor(
                     }
                 }
                 if (relevantEvents.isEmpty()) {
+                    stats.recordSkippedSelfPeer()
                     log(TAG) { "broadcast(): Skipping device=${peer.deviceId} (all events originated from this device)" }
                     return@forEach
                 }
@@ -128,10 +147,13 @@ class SyncNotifier @Inject constructor(
                 val payload = json.encodeToString(EventPayload(events = relevantEvents))
                 val result = peer.outbox.trySend(payload)
                 if (result.isSuccess) {
+                    stats.recordDelivery(relevantEvents.size)
                     log(TAG) { "broadcast(): Delivered ${relevantEvents.size} events to device=${peer.deviceId}" }
                 } else if (result.isClosed) {
+                    stats.recordClosedSession()
                     log(TAG, WARN) { "broadcast(): Session closed for device=${peer.deviceId}, skipping" }
                 } else {
+                    stats.recordBufferFullDrop()
                     log(TAG, WARN) { "broadcast(): Buffer full for device=${peer.deviceId}, dropping notification" }
                 }
             }
@@ -139,12 +161,14 @@ class SyncNotifier @Inject constructor(
             log(TAG) { "broadcast(): Debounce reset for account=$accountId" }
             throw e
         } catch (e: Exception) {
+            stats.recordFailure()
             log(TAG, WARN) { "broadcast(): Failed for account=$accountId: ${e.message}" }
         }
     }
 
     companion object {
         private const val DEBOUNCE_MS = 500L
+        private val STATS_INTERVAL: Duration = Duration.ofMinutes(1)
         private val TAG = logTag("WS", "SyncNotifier")
     }
 }

--- a/src/test/kotlin/eu/darken/octi/server/ws/SyncNotificationStatsTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/ws/SyncNotificationStatsTest.kt
@@ -1,0 +1,104 @@
+package eu.darken.octi.server.ws
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+class SyncNotificationStatsTest {
+
+    @Test
+    fun `empty snapshot produces no report`() {
+        val stats = SyncNotificationStats()
+
+        stats.snapshotAndReset() shouldBe null
+    }
+
+    @Test
+    fun `counters aggregate correctly`() {
+        val stats = SyncNotificationStats()
+
+        stats.recordBatch(
+            listOf(
+                event("eu.darken.octi.module.core.clipboard"),
+                event("eu.darken.octi.module.core.power"),
+                event("eu.darken.octi.module.core.clipboard"),
+            )
+        )
+        stats.recordDelivery(eventCount = 2)
+        stats.recordDelivery(eventCount = 1)
+        stats.recordSkippedSelfPeer()
+        stats.recordNoPeers()
+        stats.recordClosedSession()
+        stats.recordBufferFullDrop()
+        stats.recordFailure()
+
+        val snapshot = stats.snapshotAndReset()!!
+
+        snapshot shouldBe SyncNotificationStats.Snapshot(
+            batches = 1,
+            events = 3,
+            deliveredPayloads = 2,
+            deliveredEvents = 3,
+            skippedSelfPeers = 1,
+            noPeers = 1,
+            closedSessions = 1,
+            bufferFullDrops = 1,
+            failures = 1,
+            moduleCounts = mapOf(
+                "eu.darken.octi.module.core.clipboard" to 2L,
+                "eu.darken.octi.module.core.power" to 1L,
+            ),
+        )
+    }
+
+    @Test
+    fun `snapshot resets counters`() {
+        val stats = SyncNotificationStats()
+
+        stats.recordBatch(listOf(event("eu.darken.octi.module.core.clipboard")))
+
+        stats.snapshotAndReset()!!.events shouldBe 1
+        stats.snapshotAndReset() shouldBe null
+    }
+
+    @Test
+    fun `formatted line includes sorted module counts`() {
+        val snapshot = SyncNotificationStats.Snapshot(
+            batches = 2,
+            events = 8,
+            deliveredPayloads = 3,
+            deliveredEvents = 6,
+            skippedSelfPeers = 1,
+            noPeers = 1,
+            closedSessions = 1,
+            bufferFullDrops = 1,
+            failures = 0,
+            moduleCounts = mapOf(
+                "eu.darken.octi.module.core.meta" to 1L,
+                "eu.darken.octi.module.core.power" to 2L,
+                "eu.darken.octi.module.core.clipboard" to 5L,
+            ),
+        )
+
+        val line = snapshot.format(Duration.ofMinutes(1))
+
+        line shouldBe "sync-stats: 1m batches=2 events=8 " +
+            "deliveredPayloads=3 deliveredEvents=6 skippedSelfPeers=1 noPeers=1 " +
+            "closedSessions=1 bufferFullDrops=1 failures=0 " +
+            "modules=[eu.darken.octi.module.core.clipboard=5, eu.darken.octi.module.core.power=2, " +
+            "eu.darken.octi.module.core.meta=1]"
+        line shouldContain "modules=[eu.darken.octi.module.core.clipboard=5"
+    }
+
+    private fun event(moduleId: String): SyncNotifier.EventPayload.Event.ModuleChanged =
+        SyncNotifier.EventPayload.Event.ModuleChanged(
+            deviceId = UUID.randomUUID().toString(),
+            moduleId = moduleId,
+            modifiedAt = Instant.EPOCH.toString(),
+            action = "updated",
+            sourceDeviceId = UUID.randomUUID().toString(),
+        )
+}


### PR DESCRIPTION
## Summary
- Adds `SyncNotificationStats` to track WebSocket sync notification outcomes (batches, events, deliveries, skipped self-peers, no-peers, closed sessions, buffer-full drops, failures, per-module counts).
- `SyncNotifier` launches a periodic job (1 min, IO dispatcher) via the existing `launchPeriodicJob` helper that snapshots+resets the stats and emits one INFO line per non-empty window.
- Lowers the per-broadcast "Sending [...] to account=..." log from INFO to DEBUG since the aggregate now covers it.

## Test plan
- [ ] `./gradlew test --tests "eu.darken.octi.server.ws.SyncNotificationStatsTest"`
- [ ] `./gradlew test --tests "eu.darken.octi.server.ws.SyncNotifierTest"` — confirm existing tests still pass
- [ ] `./gradlew check`
- [ ] Manual: run server locally, write to a module, wait ~1 min, confirm a `sync-stats: 1m batches=... modules=[...]` line at INFO
