### PR TITLE
Improve stats logs and add build flavor split

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+scheduled_tasks.lock

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceActivityReporter.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceActivityReporter.kt
@@ -28,10 +28,17 @@ class DeviceActivityReporter @Inject constructor(
         val label: String,
         val total: Int,
         val versions: List<VersionStats>,
+        val buildFlavors: List<BuildFlavorStats>,
     )
 
     data class VersionStats(
         val version: String,
+        val count: Int,
+        val percent: Double,
+    )
+
+    data class BuildFlavorStats(
+        val flavor: String,
         val count: Int,
         val percent: Double,
     )
@@ -61,8 +68,11 @@ class DeviceActivityReporter @Inject constructor(
         private val ONE_HOUR: Duration = Duration.ofHours(1)
         private val TWENTY_FOUR_HOURS: Duration = Duration.ofHours(24)
         private const val UNKNOWN_VERSION = "<unknown>"
+        private const val UNKNOWN_BUILD_FLAVOR = "<unknown>"
         private const val MAX_VERSION_DISPLAY_LENGTH = 80
         private val CONTROL_CHARS = Regex("[\\p{Cntrl}]+")
+        private val BUILD_FLAVOR_TOKEN_SEPARATOR = Regex("[^A-Za-z0-9]+")
+        private val BUILD_FLAVOR_ORDER = listOf("FOSS", "GPLAY", UNKNOWN_BUILD_FLAVOR)
         private val TAG = logTag("Device", "Activity")
 
         internal fun buildReport(
@@ -75,7 +85,11 @@ class DeviceActivityReporter @Inject constructor(
         )
 
         internal fun formatReport(report: Report): String {
-            return "device-stats: ${formatWindow(report.oneHour)}; ${formatWindow(report.twentyFourHours)}"
+            return buildString {
+                appendLine("device-stats:")
+                appendWindow(report.oneHour)
+                appendWindow(report.twentyFourHours)
+            }.trimEnd()
         }
 
         internal fun sanitizeVersionForLog(raw: String?): String {
@@ -89,6 +103,22 @@ class DeviceActivityReporter @Inject constructor(
                 sanitized
             } else {
                 sanitized.take(MAX_VERSION_DISPLAY_LENGTH - 3) + "..."
+            }
+        }
+
+        internal fun buildFlavorForLog(raw: String?): String {
+            val sanitized = raw
+                ?.replace(CONTROL_CHARS, " ")
+                ?.trim()
+                ?.ifBlank { null }
+                ?: return UNKNOWN_BUILD_FLAVOR
+
+            val tokens = sanitized.split(BUILD_FLAVOR_TOKEN_SEPARATOR)
+
+            return when {
+                tokens.any { it.equals("FOSS", ignoreCase = true) } -> "FOSS"
+                tokens.any { it.equals("GPLAY", ignoreCase = true) || it.equals("GPLATE", ignoreCase = true) } -> "GPLAY"
+                else -> UNKNOWN_BUILD_FLAVOR
             }
         }
 
@@ -108,6 +138,10 @@ class DeviceActivityReporter @Inject constructor(
                 .groupingBy { sanitizeVersionForLog(it.version) }
                 .eachCount()
 
+            val buildFlavorCounts = activeDevices
+                .groupingBy { buildFlavorForLog(it.version) }
+                .eachCount()
+
             val total = activeDevices.size
             val versions = versionCounts.entries
                 .map { (version, count) ->
@@ -119,18 +153,43 @@ class DeviceActivityReporter @Inject constructor(
                 }
                 .sortedWith(compareByDescending<VersionStats> { it.count }.thenBy { it.version })
 
+            val buildFlavors = buildFlavorCounts.entries
+                .map { (flavor, count) ->
+                    BuildFlavorStats(
+                        flavor = flavor,
+                        count = count,
+                        percent = if (total == 0) 0.0 else count * 100.0 / total,
+                    )
+                }
+                .sortedBy { BUILD_FLAVOR_ORDER.indexOf(it.flavor).takeIf { index -> index >= 0 } ?: Int.MAX_VALUE }
+
             return WindowStats(
                 label = label,
                 total = total,
                 versions = versions,
+                buildFlavors = buildFlavors,
             )
         }
 
-        private fun formatWindow(stats: WindowStats): String {
-            val versions = stats.versions.joinToString(prefix = "[", postfix = "]") {
-                "${it.version}=${it.count} (${formatPercent(it.percent)}%)"
+        private fun StringBuilder.appendWindow(stats: WindowStats) {
+            appendLine("  ${stats.label}: total=${stats.total}")
+            appendStatsSection(
+                label = "flavors",
+                entries = stats.buildFlavors.map { "${it.flavor}=${it.count} (${formatPercent(it.percent)}%)" },
+            )
+            appendStatsSection(
+                label = "versions",
+                entries = stats.versions.map { "${it.version}=${it.count} (${formatPercent(it.percent)}%)" },
+            )
+        }
+
+        private fun StringBuilder.appendStatsSection(label: String, entries: List<String>) {
+            appendLine("    $label:")
+            if (entries.isEmpty()) {
+                appendLine("      <none>")
+            } else {
+                entries.forEach { appendLine("      $it") }
             }
-            return "${stats.label} total=${stats.total} versions=$versions"
         }
 
         private fun formatPercent(percent: Double): String = String.format(Locale.US, "%.1f", percent)

--- a/src/main/kotlin/eu/darken/octi/server/ws/SyncNotificationStats.kt
+++ b/src/main/kotlin/eu/darken/octi/server/ws/SyncNotificationStats.kt
@@ -19,13 +19,24 @@ internal class SyncNotificationStats {
         fun format(window: Duration): String {
             val modules = moduleCounts.entries
                 .sortedWith(compareByDescending<Map.Entry<String, Long>> { it.value }.thenBy { it.key })
-                .joinToString(prefix = "[", postfix = "]") { "${it.key}=${it.value}" }
 
-            return "sync-stats: ${window.toCompactString()} batches=$batches events=$events " +
-                "deliveredPayloads=$deliveredPayloads deliveredEvents=$deliveredEvents " +
-                "skippedSelfPeers=$skippedSelfPeers noPeers=$noPeers " +
-                "closedSessions=$closedSessions bufferFullDrops=$bufferFullDrops failures=$failures " +
-                "modules=$modules"
+            return buildString {
+                appendLine("sync-stats: ${window.toCompactString()}")
+                appendLine(
+                    "  traffic: batches=$batches events=$events " +
+                        "deliveredPayloads=$deliveredPayloads deliveredEvents=$deliveredEvents"
+                )
+                appendLine(
+                    "  outcomes: skippedSelfPeers=$skippedSelfPeers noPeers=$noPeers " +
+                        "closedSessions=$closedSessions bufferFullDrops=$bufferFullDrops failures=$failures"
+                )
+                appendLine("  modules:")
+                if (modules.isEmpty()) {
+                    appendLine("    <none>")
+                } else {
+                    modules.forEach { appendLine("    ${it.key}=${it.value}") }
+                }
+            }.trimEnd()
         }
     }
 

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceActivityReporterTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceActivityReporterTest.kt
@@ -13,10 +13,10 @@ class DeviceActivityReporterTest {
 
     @Test
     fun `report counts lastSeen windows and currently connected devices`() {
-        val oneHour = device(version = "octi/1.0.0", lastSeen = now.minus(Duration.ofMinutes(10)))
-        val twentyFourHours = device(version = "octi/2.0.0", lastSeen = now.minus(Duration.ofHours(2)))
-        val connected = device(version = "octi/3.0.0", lastSeen = now.minus(Duration.ofHours(30)))
-        val inactive = device(version = "octi/4.0.0", lastSeen = now.minus(Duration.ofHours(30)))
+        val oneHour = device(version = "octi/1.0.0/FOSS", lastSeen = now.minus(Duration.ofMinutes(10)))
+        val twentyFourHours = device(version = "octi/2.0.0/GPLAY", lastSeen = now.minus(Duration.ofHours(2)))
+        val connected = device(version = "octi/3.0.0/GPLAY", lastSeen = now.minus(Duration.ofHours(30)))
+        val inactive = device(version = "octi/4.0.0/FOSS", lastSeen = now.minus(Duration.ofHours(30)))
 
         val report = DeviceActivityReporter.buildReport(
             devices = listOf(oneHour, twentyFourHours, connected, inactive),
@@ -26,15 +26,23 @@ class DeviceActivityReporterTest {
 
         report.oneHour.total shouldBe 2
         report.oneHour.versionCounts() shouldBe mapOf(
-            "octi/1.0.0" to 1,
-            "octi/3.0.0" to 1,
+            "octi/1.0.0/FOSS" to 1,
+            "octi/3.0.0/GPLAY" to 1,
+        )
+        report.oneHour.buildFlavorCounts() shouldBe mapOf(
+            "FOSS" to 1,
+            "GPLAY" to 1,
         )
 
         report.twentyFourHours.total shouldBe 3
         report.twentyFourHours.versionCounts() shouldBe mapOf(
-            "octi/1.0.0" to 1,
-            "octi/2.0.0" to 1,
-            "octi/3.0.0" to 1,
+            "octi/1.0.0/FOSS" to 1,
+            "octi/2.0.0/GPLAY" to 1,
+            "octi/3.0.0/GPLAY" to 1,
+        )
+        report.twentyFourHours.buildFlavorCounts() shouldBe mapOf(
+            "FOSS" to 1,
+            "GPLAY" to 2,
         )
     }
 
@@ -42,17 +50,32 @@ class DeviceActivityReporterTest {
     fun `report formats counts and percentages sorted by count`() {
         val report = DeviceActivityReporter.buildReport(
             devices = listOf(
-                device(version = "octi/1.0.0", lastSeen = now),
-                device(version = "octi/1.0.0", lastSeen = now),
-                device(version = "octi/2.0.0", lastSeen = now),
+                device(version = "octi/1.0.0/FOSS", lastSeen = now),
+                device(version = "octi/1.0.0/FOSS", lastSeen = now),
+                device(version = "octi/2.0.0/GPLAY", lastSeen = now),
             ),
             activeDeviceKeys = emptySet(),
             now = now,
         )
 
         DeviceActivityReporter.formatReport(report) shouldBe
-            "device-stats: 1h total=3 versions=[octi/1.0.0=2 (66.7%), octi/2.0.0=1 (33.3%)]; " +
-            "24h total=3 versions=[octi/1.0.0=2 (66.7%), octi/2.0.0=1 (33.3%)]"
+            """
+            device-stats:
+              1h: total=3
+                flavors:
+                  FOSS=2 (66.7%)
+                  GPLAY=1 (33.3%)
+                versions:
+                  octi/1.0.0/FOSS=2 (66.7%)
+                  octi/2.0.0/GPLAY=1 (33.3%)
+              24h: total=3
+                flavors:
+                  FOSS=2 (66.7%)
+                  GPLAY=1 (33.3%)
+                versions:
+                  octi/1.0.0/FOSS=2 (66.7%)
+                  octi/2.0.0/GPLAY=1 (33.3%)
+            """.trimIndent()
     }
 
     @Test
@@ -64,6 +87,7 @@ class DeviceActivityReporterTest {
         )
         empty.oneHour.total shouldBe 0
         empty.oneHour.versions shouldBe emptyList()
+        empty.oneHour.buildFlavors shouldBe emptyList()
 
         val report = DeviceActivityReporter.buildReport(
             devices = listOf(
@@ -77,6 +101,13 @@ class DeviceActivityReporterTest {
         report.oneHour.versions shouldBe listOf(
             DeviceActivityReporter.VersionStats(
                 version = "<unknown>",
+                count = 2,
+                percent = 100.0,
+            )
+        )
+        report.oneHour.buildFlavors shouldBe listOf(
+            DeviceActivityReporter.BuildFlavorStats(
+                flavor = "<unknown>",
                 count = 2,
                 percent = 100.0,
             )
@@ -121,8 +152,21 @@ class DeviceActivityReporterTest {
         sanitized.endsWith("...") shouldBe true
     }
 
+    @Test
+    fun `build flavor is parsed from user-agent style versions`() {
+        DeviceActivityReporter.buildFlavorForLog("octi/1.2.3/FOSS") shouldBe "FOSS"
+        DeviceActivityReporter.buildFlavorForLog("octi/1.2.3/gplay/dev-a1b2c3d") shouldBe "GPLAY"
+        DeviceActivityReporter.buildFlavorForLog("octi/1.2.3/GPLATE") shouldBe "GPLAY"
+        DeviceActivityReporter.buildFlavorForLog("1.2.3") shouldBe "<unknown>"
+        DeviceActivityReporter.buildFlavorForLog(null) shouldBe "<unknown>"
+    }
+
     private fun DeviceActivityReporter.WindowStats.versionCounts(): Map<String, Int> {
         return versions.associate { it.version to it.count }
+    }
+
+    private fun DeviceActivityReporter.WindowStats.buildFlavorCounts(): Map<String, Int> {
+        return buildFlavors.associate { it.flavor to it.count }
     }
 
     private fun device(

--- a/src/test/kotlin/eu/darken/octi/server/ws/SyncNotificationStatsTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/ws/SyncNotificationStatsTest.kt
@@ -85,12 +85,16 @@ class SyncNotificationStatsTest {
 
         val line = snapshot.format(Duration.ofMinutes(1))
 
-        line shouldBe "sync-stats: 1m batches=2 events=8 " +
-            "deliveredPayloads=3 deliveredEvents=6 skippedSelfPeers=1 noPeers=1 " +
-            "closedSessions=1 bufferFullDrops=1 failures=0 " +
-            "modules=[eu.darken.octi.module.core.clipboard=5, eu.darken.octi.module.core.power=2, " +
-            "eu.darken.octi.module.core.meta=1]"
-        line shouldContain "modules=[eu.darken.octi.module.core.clipboard=5"
+        line shouldBe """
+            sync-stats: 1m
+              traffic: batches=2 events=8 deliveredPayloads=3 deliveredEvents=6
+              outcomes: skippedSelfPeers=1 noPeers=1 closedSessions=1 bufferFullDrops=1 failures=0
+              modules:
+                eu.darken.octi.module.core.clipboard=5
+                eu.darken.octi.module.core.power=2
+                eu.darken.octi.module.core.meta=1
+        """.trimIndent()
+        line shouldContain "\n    eu.darken.octi.module.core.clipboard=5"
     }
 
     private fun event(moduleId: String): SyncNotifier.EventPayload.Event.ModuleChanged =


### PR DESCRIPTION
## Summary
- add FOSS/GPLAY split to device-stats windows
- format device-stats and sync-stats as readable multiline blocks
- include focused formatter tests

## Test
- `./gradlew test --tests eu.darken.octi.server.device.DeviceActivityReporterTest --tests eu.darken.octi.server.ws.SyncNotificationStatsTest`