### PR TITLE
feat: tracker-only device stats with auth-failure tracking

### DIFF
--- a/src/main/kotlin/eu/darken/octi/server/AppComponent.kt
+++ b/src/main/kotlin/eu/darken/octi/server/AppComponent.kt
@@ -5,6 +5,7 @@ import dagger.Component
 import eu.darken.octi.server.account.AccountRepo
 import eu.darken.octi.server.account.AccountStorageTracker
 import eu.darken.octi.server.common.serialization.SerializationModule
+import eu.darken.octi.server.device.DeviceClientIdentityTracker
 import eu.darken.octi.server.device.DeviceRepo
 import eu.darken.octi.server.module.ModuleLifecycleService
 import eu.darken.octi.server.module.ModuleRepo
@@ -29,6 +30,7 @@ interface AppComponent {
     fun lifecycleService(): ModuleLifecycleService
     fun accountRepo(): AccountRepo
     fun deviceRepo(): DeviceRepo
+    fun deviceClientIdentityTracker(): DeviceClientIdentityTracker
     fun json(): Json
 
     @Component.Builder

--- a/src/main/kotlin/eu/darken/octi/server/Server.kt
+++ b/src/main/kotlin/eu/darken/octi/server/Server.kt
@@ -11,12 +11,14 @@ import eu.darken.octi.server.common.debug.logging.log
 import eu.darken.octi.server.common.debug.logging.logTag
 import eu.darken.octi.server.common.AccountRateLimiter
 import eu.darken.octi.server.common.AccountRateLimiterKey
+import eu.darken.octi.server.common.DeviceClientIdentityTrackerKey
 import eu.darken.octi.server.common.IpDeviceTracker
 import eu.darken.octi.server.common.IpDeviceTrackerKey
 import eu.darken.octi.server.common.TrustedProxyIpsKey
 import eu.darken.octi.server.common.installCallLogging
 import eu.darken.octi.server.common.installRateLimit
 import io.ktor.server.plugins.bodylimit.*
+import eu.darken.octi.server.device.DeviceClientIdentityTracker
 import eu.darken.octi.server.device.DeviceRoute
 import eu.darken.octi.server.module.BlobRoute
 import eu.darken.octi.server.module.ModuleRoute
@@ -56,6 +58,7 @@ class Server @Inject constructor(
     private val serializers: SerializersModule,
     private val ipDeviceTracker: IpDeviceTracker,
     private val accountRateLimiter: AccountRateLimiter,
+    private val deviceClientIdentityTracker: DeviceClientIdentityTracker,
 ) {
 
     @Suppress("ExtractKtorModule")
@@ -111,6 +114,7 @@ class Server @Inject constructor(
             attributes.put(IpDeviceTrackerKey, ipDeviceTracker)
             attributes.put(AccountRateLimiterKey, accountRateLimiter)
             attributes.put(TrustedProxyIpsKey, config.trustedProxyIps)
+            attributes.put(DeviceClientIdentityTrackerKey, deviceClientIdentityTracker)
 
             config.rateLimit
                 ?.let { installRateLimit(it, ipDeviceTracker, config.trustedProxyIps) }

--- a/src/main/kotlin/eu/darken/octi/server/account/AccountRoute.kt
+++ b/src/main/kotlin/eu/darken/octi/server/account/AccountRoute.kt
@@ -11,11 +11,13 @@ import eu.darken.octi.server.common.debug.logging.shortId
 import eu.darken.octi.server.common.headerDeviceId
 import eu.darken.octi.server.common.normalizeLabel
 import eu.darken.octi.server.common.verifyCaller
+import eu.darken.octi.server.device.DeviceClientIdentityTracker
 import eu.darken.octi.server.device.DeviceLimitExceededException
 import eu.darken.octi.server.device.DeviceRepo
 import eu.darken.octi.server.device.deviceCredentials
 import eu.darken.octi.server.module.ModuleLifecycleService
 import io.ktor.http.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.NonCancellable
@@ -29,6 +31,7 @@ class AccountRoute @Inject constructor(
     private val deviceRepo: DeviceRepo,
     private val shareRepo: ShareRepo,
     private val lifecycleService: ModuleLifecycleService,
+    private val deviceClientIdentityTracker: DeviceClientIdentityTracker,
 ) {
 
     fun setup(rootRoute: Routing) {
@@ -108,6 +111,8 @@ class AccountRoute @Inject constructor(
             }
             throw e
         }
+
+        deviceClientIdentityTracker.recordUserAgent(device.key, call.request.userAgent())
 
         val response = RegisterResponse(
             accountID = device.accountId,

--- a/src/main/kotlin/eu/darken/octi/server/common/HttpExtensions.kt
+++ b/src/main/kotlin/eu/darken/octi/server/common/HttpExtensions.kt
@@ -4,6 +4,7 @@ import eu.darken.octi.server.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.server.common.debug.logging.log
 import eu.darken.octi.server.common.debug.logging.logTag
 import eu.darken.octi.server.device.Device
+import eu.darken.octi.server.device.DeviceClientIdentityTracker
 import eu.darken.octi.server.device.DeviceId
 import eu.darken.octi.server.device.DeviceKey
 import eu.darken.octi.server.device.DeviceRepo
@@ -17,6 +18,7 @@ import java.time.Instant
 import java.util.*
 
 val IpDeviceTrackerKey = AttributeKey<IpDeviceTracker>("IpDeviceTracker")
+val DeviceClientIdentityTrackerKey = AttributeKey<DeviceClientIdentityTracker>("DeviceClientIdentityTracker")
 
 private val TAG = logTag("Auth")
 
@@ -35,7 +37,7 @@ val RoutingCall.headerDeviceId: DeviceId?
 
 sealed interface AuthResult {
     data class Success(val deviceId: DeviceId, val device: Device) : AuthResult
-    data class Failure(val reason: String, val status: HttpStatusCode) : AuthResult
+    data class Failure(val reason: String, val tag: String, val status: HttpStatusCode) : AuthResult
 }
 
 data class DeviceMetadataPatch(
@@ -58,16 +60,32 @@ suspend fun authenticateDevice(
     deviceRepo: DeviceRepo,
 ): AuthResult {
     val deviceId = parseDeviceId(deviceIdHeader)
-        ?: return AuthResult.Failure("X-Device-ID header is missing", HttpStatusCode.BadRequest)
+        ?: return AuthResult.Failure(
+            reason = "X-Device-ID header is missing",
+            tag = "missing-device-id",
+            status = HttpStatusCode.BadRequest,
+        )
 
     val creds = DeviceCredentials.parseFromHeader(authHeader)
-        ?: return AuthResult.Failure("Device credentials are missing", HttpStatusCode.BadRequest)
+        ?: return AuthResult.Failure(
+            reason = "Device credentials are missing",
+            tag = "missing-credentials",
+            status = HttpStatusCode.BadRequest,
+        )
 
     val device = deviceRepo.getDevice(DeviceKey(creds.accountId, deviceId))
-        ?: return AuthResult.Failure("Unknown device: $deviceId", HttpStatusCode.NotFound)
+        ?: return AuthResult.Failure(
+            reason = "Unknown device: $deviceId",
+            tag = "unknown-device",
+            status = HttpStatusCode.NotFound,
+        )
 
     if (!device.isAuthorized(creds)) {
-        return AuthResult.Failure("Device credentials not found or insufficient", HttpStatusCode.Unauthorized)
+        return AuthResult.Failure(
+            reason = "Device credentials not found or insufficient",
+            tag = "bad-credentials",
+            status = HttpStatusCode.Unauthorized,
+        )
     }
 
     return AuthResult.Success(deviceId, device)
@@ -122,6 +140,7 @@ fun parseStrongEtag(raw: String): String? {
 suspend fun RoutingContext.verifyCaller(tag: String, deviceRepo: DeviceRepo): Device? {
     val ipTracker = call.application.attributes.getOrNull(IpDeviceTrackerKey)
     val accountRateLimiter = call.application.attributes.getOrNull(AccountRateLimiterKey)
+    val deviceClientIdentityTracker = call.application.attributes.getOrNull(DeviceClientIdentityTrackerKey)
 
     // 1. Validate credentials (no side effects).
     val result = authenticateDevice(
@@ -133,10 +152,13 @@ suspend fun RoutingContext.verifyCaller(tag: String, deviceRepo: DeviceRepo): De
         is AuthResult.Success -> result.device
         is AuthResult.Failure -> {
             log(tag, WARN) { "verifyAuth(): ${result.reason}" }
+            deviceClientIdentityTracker?.recordAuthFailure(result.tag, call.request.userAgent())
             call.respond(result.status, result.reason)
             return null
         }
     }
+
+    deviceClientIdentityTracker?.recordUserAgent(device.key, call.request.userAgent())
 
     // 2. Per-account rate-limit gate. Over-limit calls don't get to update lastSeen.
     if (accountRateLimiter != null) {

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceActivityReporter.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceActivityReporter.kt
@@ -5,7 +5,8 @@ import eu.darken.octi.server.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.server.common.debug.logging.log
 import eu.darken.octi.server.common.debug.logging.logTag
 import eu.darken.octi.server.common.launchPeriodicJob
-import eu.darken.octi.server.ws.ConnectionRegistry
+import eu.darken.octi.server.device.DeviceClientIdentityTracker.AuthFailureEvent
+import eu.darken.octi.server.device.DeviceClientIdentityTracker.TrackedActivity
 import java.time.Duration
 import java.time.Instant
 import java.util.Locale
@@ -16,7 +17,7 @@ import javax.inject.Singleton
 class DeviceActivityReporter @Inject constructor(
     appScope: AppScope,
     private val deviceRepo: DeviceRepo,
-    private val connectionRegistry: ConnectionRegistry,
+    private val clientIdentityTracker: DeviceClientIdentityTracker,
 ) {
 
     data class Report(
@@ -29,6 +30,7 @@ class DeviceActivityReporter @Inject constructor(
         val total: Int,
         val versions: List<VersionStats>,
         val buildFlavors: List<BuildFlavorStats>,
+        val authFailures: AuthFailureStats,
     )
 
     data class VersionStats(
@@ -43,6 +45,22 @@ class DeviceActivityReporter @Inject constructor(
         val percent: Double,
     )
 
+    data class AuthFailureStats(
+        val total: Int,
+        val byReason: List<ReasonBreakdown>,
+    )
+
+    data class ReasonBreakdown(
+        val reasonTag: String,
+        val count: Int,
+        val topUserAgents: List<UserAgentCount>,
+    )
+
+    data class UserAgentCount(
+        val userAgent: String,
+        val count: Int,
+    )
+
     init {
         appScope.launchPeriodicJob(
             tag = TAG,
@@ -55,9 +73,10 @@ class DeviceActivityReporter @Inject constructor(
     }
 
     internal fun logReport(now: Instant = Instant.now()) {
+        clientIdentityTracker.retainDevices(deviceRepo.allDevices().map { it.key }.toSet())
         val report = buildReport(
-            devices = deviceRepo.allDevices(),
-            activeDeviceKeys = connectionRegistry.activeDeviceKeys(),
+            activity = clientIdentityTracker.snapshotActivity(),
+            failures = clientIdentityTracker.snapshotAuthFailures(now),
             now = now,
         )
         log(TAG, INFO) { formatReport(report) }
@@ -69,19 +88,21 @@ class DeviceActivityReporter @Inject constructor(
         private val TWENTY_FOUR_HOURS: Duration = Duration.ofHours(24)
         private const val UNKNOWN_VERSION = "<unknown>"
         private const val UNKNOWN_BUILD_FLAVOR = "<unknown>"
+        private const val UNKNOWN_USER_AGENT = "<unknown>"
         private const val MAX_VERSION_DISPLAY_LENGTH = 80
+        private const val FAILURE_TOP_USER_AGENTS = 5
         private val CONTROL_CHARS = Regex("[\\p{Cntrl}]+")
         private val BUILD_FLAVOR_TOKEN_SEPARATOR = Regex("[^A-Za-z0-9]+")
         private val BUILD_FLAVOR_ORDER = listOf("FOSS", "GPLAY", UNKNOWN_BUILD_FLAVOR)
         private val TAG = logTag("Device", "Activity")
 
         internal fun buildReport(
-            devices: Collection<Device>,
-            activeDeviceKeys: Set<DeviceKey>,
+            activity: Map<DeviceKey, TrackedActivity>,
+            failures: List<AuthFailureEvent> = emptyList(),
             now: Instant = Instant.now(),
         ): Report = Report(
-            oneHour = buildWindowStats("1h", ONE_HOUR, devices, activeDeviceKeys, now),
-            twentyFourHours = buildWindowStats("24h", TWENTY_FOUR_HOURS, devices, activeDeviceKeys, now),
+            oneHour = buildWindowStats("1h", ONE_HOUR, activity, failures, now),
+            twentyFourHours = buildWindowStats("24h", TWENTY_FOUR_HOURS, activity, failures, now),
         )
 
         internal fun formatReport(report: Report): String {
@@ -93,24 +114,27 @@ class DeviceActivityReporter @Inject constructor(
         }
 
         internal fun sanitizeVersionForLog(raw: String?): String {
-            val sanitized = raw
-                ?.replace(CONTROL_CHARS, " ")
-                ?.trim()
-                ?.ifBlank { null }
+            val sanitized = sanitizeForLog(raw)
                 ?: return UNKNOWN_VERSION
 
-            return if (sanitized.length <= MAX_VERSION_DISPLAY_LENGTH) {
-                sanitized
+            return truncateVersionForLog(sanitized)
+        }
+
+        internal fun appVersionForLog(raw: String?): String {
+            val sanitized = sanitizeForLog(raw)
+                ?: return UNKNOWN_VERSION
+
+            val version = if (sanitized.startsWith("octi/", ignoreCase = true)) {
+                sanitized.split("/", limit = 3).getOrNull(1)?.trim()?.ifBlank { null }
             } else {
-                sanitized.take(MAX_VERSION_DISPLAY_LENGTH - 3) + "..."
-            }
+                sanitized
+            } ?: return UNKNOWN_VERSION
+
+            return truncateVersionForLog(version)
         }
 
         internal fun buildFlavorForLog(raw: String?): String {
-            val sanitized = raw
-                ?.replace(CONTROL_CHARS, " ")
-                ?.trim()
-                ?.ifBlank { null }
+            val sanitized = sanitizeForLog(raw)
                 ?: return UNKNOWN_BUILD_FLAVOR
 
             val tokens = sanitized.split(BUILD_FLAVOR_TOKEN_SEPARATOR)
@@ -122,24 +146,43 @@ class DeviceActivityReporter @Inject constructor(
             }
         }
 
+        private fun sanitizeForLog(raw: String?): String? {
+            return raw
+                ?.replace(CONTROL_CHARS, " ")
+                ?.trim()
+                ?.ifBlank { null }
+        }
+
+        private fun truncateVersionForLog(sanitized: String): String {
+            return if (sanitized.length <= MAX_VERSION_DISPLAY_LENGTH) {
+                sanitized
+            } else {
+                sanitized.take(MAX_VERSION_DISPLAY_LENGTH - 3) + "..."
+            }
+        }
+
+        private fun userAgentLabel(raw: String): String {
+            return sanitizeForLog(raw)
+                ?.let { truncateVersionForLog(it) }
+                ?: UNKNOWN_USER_AGENT
+        }
+
         private fun buildWindowStats(
             label: String,
             window: Duration,
-            devices: Collection<Device>,
-            activeDeviceKeys: Set<DeviceKey>,
+            activity: Map<DeviceKey, TrackedActivity>,
+            failures: List<AuthFailureEvent>,
             now: Instant,
         ): WindowStats {
             val cutoff = now.minus(window)
-            val activeDevices = devices.filter { device ->
-                !device.lastSeen.isBefore(cutoff) || device.key in activeDeviceKeys
-            }
+            val activeDevices = activity.values.filter { !it.seenAt.isBefore(cutoff) }
 
             val versionCounts = activeDevices
-                .groupingBy { sanitizeVersionForLog(it.version) }
+                .groupingBy { appVersionForLog(it.userAgent.ifEmpty { null }) }
                 .eachCount()
 
             val buildFlavorCounts = activeDevices
-                .groupingBy { buildFlavorForLog(it.version) }
+                .groupingBy { buildFlavorForLog(it.userAgent.ifEmpty { null }) }
                 .eachCount()
 
             val total = activeDevices.size
@@ -163,12 +206,36 @@ class DeviceActivityReporter @Inject constructor(
                 }
                 .sortedBy { BUILD_FLAVOR_ORDER.indexOf(it.flavor).takeIf { index -> index >= 0 } ?: Int.MAX_VALUE }
 
+            val authFailureStats = buildAuthFailureStats(failures, cutoff)
+
             return WindowStats(
                 label = label,
                 total = total,
                 versions = versions,
                 buildFlavors = buildFlavors,
+                authFailures = authFailureStats,
             )
+        }
+
+        private fun buildAuthFailureStats(
+            failures: List<AuthFailureEvent>,
+            cutoff: Instant,
+        ): AuthFailureStats {
+            val windowed = failures.filter { !it.seenAt.isBefore(cutoff) }
+            val byReason = windowed
+                .groupBy { it.reasonTag }
+                .map { (reason, events) ->
+                    val topUserAgents = events
+                        .groupingBy { userAgentLabel(it.userAgent) }
+                        .eachCount()
+                        .entries
+                        .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
+                        .take(FAILURE_TOP_USER_AGENTS)
+                        .map { UserAgentCount(it.key, it.value) }
+                    ReasonBreakdown(reasonTag = reason, count = events.size, topUserAgents = topUserAgents)
+                }
+                .sortedWith(compareByDescending<ReasonBreakdown> { it.count }.thenBy { it.reasonTag })
+            return AuthFailureStats(total = windowed.size, byReason = byReason)
         }
 
         private fun StringBuilder.appendWindow(stats: WindowStats) {
@@ -181,6 +248,21 @@ class DeviceActivityReporter @Inject constructor(
                 label = "versions",
                 entries = stats.versions.map { "${it.version}=${it.count} (${formatPercent(it.percent)}%)" },
             )
+            appendAuthFailures(stats.authFailures)
+        }
+
+        private fun StringBuilder.appendAuthFailures(stats: AuthFailureStats) {
+            appendLine("    auth-failures: total=${stats.total}")
+            if (stats.byReason.isEmpty()) {
+                appendLine("      <none>")
+                return
+            }
+            stats.byReason.forEach { reason ->
+                appendLine("      ${reason.reasonTag}=${reason.count}")
+                reason.topUserAgents.forEach { ua ->
+                    appendLine("        ${ua.userAgent}=${ua.count}")
+                }
+            }
         }
 
         private fun StringBuilder.appendStatsSection(label: String, entries: List<String>) {

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceClientIdentityTracker.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceClientIdentityTracker.kt
@@ -1,0 +1,93 @@
+package eu.darken.octi.server.device
+
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * In-memory client-identity tracker used for the device-activity log.
+ * Stores the last User-Agent and `seenAt` per device for successful auth, and a capped
+ * stream of failed-auth events. Not authoritative — wiped on restart.
+ */
+@Singleton
+class DeviceClientIdentityTracker @Inject constructor() {
+
+    data class TrackedActivity(
+        val userAgent: String,
+        val seenAt: Instant,
+    )
+
+    data class AuthFailureEvent(
+        val seenAt: Instant,
+        val reasonTag: String,
+        val userAgent: String,
+    )
+
+    private val activity = ConcurrentHashMap<DeviceKey, TrackedActivity>()
+
+    // Cap eviction is FIFO by insertion order between snapshots — see snapshotAuthFailures
+    // for age-based pruning. The synchronized block keeps insert + cap-trim and the snapshot
+    // prune atomic w.r.t. each other; ArrayDeque gives O(1) size/addLast/removeFirst, so the
+    // hot-path traversal cost of ConcurrentLinkedDeque.size is gone.
+    private val authFailuresLock = Any()
+    private val authFailures = ArrayDeque<AuthFailureEvent>()
+
+    fun recordUserAgent(key: DeviceKey, rawUserAgent: String?, seenAt: Instant = Instant.now()) {
+        val normalized = normalizeOctiUserAgent(rawUserAgent)
+        activity.compute(key) { _, existing ->
+            val ua = normalized ?: existing?.userAgent ?: ""
+            TrackedActivity(userAgent = ua, seenAt = seenAt)
+        }
+    }
+
+    fun userAgentFor(key: DeviceKey): String? = activity[key]?.userAgent?.takeIf { it.isNotEmpty() }
+
+    fun retainDevices(keys: Set<DeviceKey>) {
+        activity.keys.retainAll(keys)
+    }
+
+    fun snapshotActivity(): Map<DeviceKey, TrackedActivity> = activity.toMap()
+
+    fun recordAuthFailure(reasonTag: String, rawUserAgent: String?, seenAt: Instant = Instant.now()) {
+        val event = AuthFailureEvent(
+            seenAt = seenAt,
+            reasonTag = reasonTag,
+            userAgent = sanitizeUserAgent(rawUserAgent) ?: "",
+        )
+        synchronized(authFailuresLock) {
+            authFailures.addLast(event)
+            while (authFailures.size > MAX_FAILURE_EVENTS) {
+                authFailures.removeFirst()
+            }
+        }
+    }
+
+    fun snapshotAuthFailures(now: Instant = Instant.now()): List<AuthFailureEvent> {
+        val cutoff = now.minus(FAILURE_RETENTION)
+        return synchronized(authFailuresLock) {
+            authFailures.removeAll { it.seenAt.isBefore(cutoff) }
+            authFailures.toList()
+        }
+    }
+
+    companion object {
+        internal const val MAX_FAILURE_EVENTS = 10_000
+        private val FAILURE_RETENTION: Duration = Duration.ofHours(24)
+        private const val MAX_USER_AGENT_LENGTH = 256
+        private val CONTROL_CHARS = Regex("\\p{Cntrl}+")
+
+        private fun sanitizeUserAgent(raw: String?): String? {
+            return raw
+                ?.replace(CONTROL_CHARS, " ")
+                ?.trim()
+                ?.ifBlank { null }
+                ?.take(MAX_USER_AGENT_LENGTH)
+        }
+
+        private fun normalizeOctiUserAgent(raw: String?): String? {
+            return sanitizeUserAgent(raw)?.takeIf { it.startsWith("octi/", ignoreCase = true) }
+        }
+    }
+}

--- a/src/main/kotlin/eu/darken/octi/server/ws/WsRoute.kt
+++ b/src/main/kotlin/eu/darken/octi/server/ws/WsRoute.kt
@@ -13,7 +13,9 @@ import eu.darken.octi.server.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.server.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.server.common.debug.logging.log
 import eu.darken.octi.server.common.debug.logging.logTag
+import eu.darken.octi.server.device.DeviceClientIdentityTracker
 import eu.darken.octi.server.device.DeviceRepo
+import io.ktor.server.request.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
 import io.ktor.websocket.*
@@ -32,6 +34,7 @@ class WsRoute @Inject constructor(
     private val connectionRegistry: ConnectionRegistry,
     private val ipDeviceTracker: IpDeviceTracker,
     private val accountRateLimiter: AccountRateLimiter,
+    private val deviceClientIdentityTracker: DeviceClientIdentityTracker,
 ) {
 
     fun setup(rootRoute: Routing) {
@@ -45,10 +48,13 @@ class WsRoute @Inject constructor(
                 is AuthResult.Success -> authResult
                 is AuthResult.Failure -> {
                     log(TAG, WARN) { "WS auth failed: ${authResult.reason}" }
+                    deviceClientIdentityTracker.recordAuthFailure(authResult.tag, call.request.userAgent())
                     close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Authentication failed"))
                     return@webSocket
                 }
             }
+
+            deviceClientIdentityTracker.recordUserAgent(auth.device.key, call.request.userAgent())
 
             // Per-account rate-limit applies to WS connection establishment too.
             if (accountRateLimiter.acquire(auth.device.accountId) is AccountRateLimiter.Decision.Rejected) {

--- a/src/test/kotlin/eu/darken/octi/TestRunnerExtensions.kt
+++ b/src/test/kotlin/eu/darken/octi/TestRunnerExtensions.kt
@@ -59,6 +59,7 @@ suspend fun TestEnvironment.createDeviceRaw(
     version: String? = null,
     platform: String? = null,
     label: String? = null,
+    userAgent: String? = null,
 ): HttpResponse = this.http.run {
     post {
         url {
@@ -69,6 +70,7 @@ suspend fun TestEnvironment.createDeviceRaw(
         if (version != null) headers.append("Octi-Device-Version", version)
         if (platform != null) headers.append("Octi-Device-Platform", platform)
         if (label != null) headers.append("Octi-Device-Label", label)
+        if (userAgent != null) headers.set(HttpHeaders.UserAgent, userAgent)
     }
 }
 
@@ -78,8 +80,9 @@ suspend fun TestEnvironment.createDevice(
     version: String? = null,
     platform: String? = null,
     label: String? = null,
+    userAgent: String? = null,
 ): Credentials {
-    val credentials = createDeviceRaw(deviceId, shareCode, version, platform, label).asAuth()
+    val credentials = createDeviceRaw(deviceId, shareCode, version, platform, label, userAgent).asAuth()
     return Credentials(deviceId, credentials)
 }
 

--- a/src/test/kotlin/eu/darken/octi/server/account/AccountRateLimitFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/account/AccountRateLimitFlowTest.kt
@@ -1,10 +1,12 @@
 package eu.darken.octi.server.account
 
 import eu.darken.octi.*
+import eu.darken.octi.server.device.DeviceKey
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.*
 import io.ktor.http.*
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 /**
  * Verifies the per-account rate limit gate (G4 / P5.2). The gate runs after
@@ -27,6 +29,31 @@ class AccountRateLimitFlowTest : TestRunner() {
         http.get("/v1/account/storage") { addCredentials(creds) }.status shouldBe HttpStatusCode.OK
         http.get("/v1/account/storage") { addCredentials(creds) }.status shouldBe HttpStatusCode.OK
         http.get("/v1/account/storage") { addCredentials(creds) }.status shouldBe HttpStatusCode.TooManyRequests
+    }
+
+    @Test
+    fun `over-limit authenticated request still records client identity`() = runTest2(
+        appConfig = baseConfig.copy(
+            accountRateLimit = 1,
+            accountRateLimitWindowSeconds = 60,
+        ),
+    ) {
+        val firstUserAgent = "octi/1.0.0/FOSS"
+        val overLimitUserAgent = "octi/2.0.0/GPLAY"
+        val creds = createDevice()
+        val key = DeviceKey(UUID.fromString(creds.account), creds.deviceId)
+
+        http.get("/v1/account/storage") {
+            addCredentials(creds)
+            headers.set(HttpHeaders.UserAgent, firstUserAgent)
+        }.status shouldBe HttpStatusCode.OK
+
+        http.get("/v1/account/storage") {
+            addCredentials(creds)
+            headers.set(HttpHeaders.UserAgent, overLimitUserAgent)
+        }.status shouldBe HttpStatusCode.TooManyRequests
+
+        component.deviceClientIdentityTracker().userAgentFor(key) shouldBe overLimitUserAgent
     }
 
     @Test

--- a/src/test/kotlin/eu/darken/octi/server/common/AuthenticateDeviceTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/common/AuthenticateDeviceTest.kt
@@ -83,6 +83,18 @@ class AuthenticateDeviceTest {
 
         result.shouldBeInstanceOf<AuthResult.Failure>()
         result.status.value shouldBe 400
+        result.tag shouldBe "missing-device-id"
+    }
+
+    @Test
+    fun `blank or malformed device ID also tags missing-device-id`() = runTest {
+        val blank = authenticateDevice(deviceIdHeader = "   ", authHeader = basicAuth(), deviceRepo = deviceRepo)
+        blank.shouldBeInstanceOf<AuthResult.Failure>()
+        blank.tag shouldBe "missing-device-id"
+
+        val malformed = authenticateDevice(deviceIdHeader = "not-a-uuid", authHeader = basicAuth(), deviceRepo = deviceRepo)
+        malformed.shouldBeInstanceOf<AuthResult.Failure>()
+        malformed.tag shouldBe "missing-device-id"
     }
 
     @Test
@@ -95,6 +107,57 @@ class AuthenticateDeviceTest {
 
         result.shouldBeInstanceOf<AuthResult.Failure>()
         result.status.value shouldBe 400
+        result.tag shouldBe "missing-credentials"
+    }
+
+    @Test
+    fun `non-Basic auth scheme tags missing-credentials`() = runTest {
+        val result = authenticateDevice(
+            deviceIdHeader = deviceId.toString(),
+            authHeader = "Bearer some-token",
+            deviceRepo = deviceRepo,
+        )
+
+        result.shouldBeInstanceOf<AuthResult.Failure>()
+        result.tag shouldBe "missing-credentials"
+    }
+
+    @Test
+    fun `invalid base64 in Basic auth tags missing-credentials`() = runTest {
+        val result = authenticateDevice(
+            deviceIdHeader = deviceId.toString(),
+            authHeader = "Basic ##not-base64##",
+            deviceRepo = deviceRepo,
+        )
+
+        result.shouldBeInstanceOf<AuthResult.Failure>()
+        result.tag shouldBe "missing-credentials"
+    }
+
+    @Test
+    fun `Basic auth payload without colon tags missing-credentials`() = runTest {
+        val payload = Base64.getEncoder().encodeToString("no-colon-here".toByteArray())
+        val result = authenticateDevice(
+            deviceIdHeader = deviceId.toString(),
+            authHeader = "Basic $payload",
+            deviceRepo = deviceRepo,
+        )
+
+        result.shouldBeInstanceOf<AuthResult.Failure>()
+        result.tag shouldBe "missing-credentials"
+    }
+
+    @Test
+    fun `Basic auth with non-UUID account tags missing-credentials`() = runTest {
+        val payload = Base64.getEncoder().encodeToString("not-a-uuid:password".toByteArray())
+        val result = authenticateDevice(
+            deviceIdHeader = deviceId.toString(),
+            authHeader = "Basic $payload",
+            deviceRepo = deviceRepo,
+        )
+
+        result.shouldBeInstanceOf<AuthResult.Failure>()
+        result.tag shouldBe "missing-credentials"
     }
 
     @Test
@@ -110,6 +173,7 @@ class AuthenticateDeviceTest {
 
         result.shouldBeInstanceOf<AuthResult.Failure>()
         result.status.value shouldBe 404
+        result.tag shouldBe "unknown-device"
     }
 
     @Test
@@ -122,6 +186,7 @@ class AuthenticateDeviceTest {
 
         result.shouldBeInstanceOf<AuthResult.Failure>()
         result.status.value shouldBe 401
+        result.tag shouldBe "bad-credentials"
     }
 }
 

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceActivityReporterTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceActivityReporterTest.kt
@@ -1,8 +1,9 @@
 package eu.darken.octi.server.device
 
+import eu.darken.octi.server.device.DeviceClientIdentityTracker.AuthFailureEvent
+import eu.darken.octi.server.device.DeviceClientIdentityTracker.TrackedActivity
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
-import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
 import java.util.UUID
@@ -12,51 +13,39 @@ class DeviceActivityReporterTest {
     private val now: Instant = Instant.parse("2026-04-29T12:00:00Z")
 
     @Test
-    fun `report counts lastSeen windows and currently connected devices`() {
-        val oneHour = device(version = "octi/1.0.0/FOSS", lastSeen = now.minus(Duration.ofMinutes(10)))
-        val twentyFourHours = device(version = "octi/2.0.0/GPLAY", lastSeen = now.minus(Duration.ofHours(2)))
-        val connected = device(version = "octi/3.0.0/GPLAY", lastSeen = now.minus(Duration.ofHours(30)))
-        val inactive = device(version = "octi/4.0.0/FOSS", lastSeen = now.minus(Duration.ofHours(30)))
-
-        val report = DeviceActivityReporter.buildReport(
-            devices = listOf(oneHour, twentyFourHours, connected, inactive),
-            activeDeviceKeys = setOf(connected.key),
-            now = now,
+    fun `report buckets activity by seenAt windows`() {
+        val activity = mapOf(
+            randomKey() to TrackedActivity("octi/1.0.0/FOSS", seenAt = now.minus(Duration.ofMinutes(10))),
+            randomKey() to TrackedActivity("octi/2.0.0/GPLAY", seenAt = now.minus(Duration.ofHours(2))),
+            randomKey() to TrackedActivity("octi/3.0.0/GPLAY", seenAt = now.minus(Duration.ofHours(30))),
         )
 
-        report.oneHour.total shouldBe 2
-        report.oneHour.versionCounts() shouldBe mapOf(
-            "octi/1.0.0/FOSS" to 1,
-            "octi/3.0.0/GPLAY" to 1,
-        )
-        report.oneHour.buildFlavorCounts() shouldBe mapOf(
-            "FOSS" to 1,
-            "GPLAY" to 1,
-        )
+        val report = DeviceActivityReporter.buildReport(activity = activity, now = now)
 
-        report.twentyFourHours.total shouldBe 3
+        report.oneHour.total shouldBe 1
+        report.oneHour.versionCounts() shouldBe mapOf("1.0.0" to 1)
+        report.oneHour.buildFlavorCounts() shouldBe mapOf("FOSS" to 1)
+
+        report.twentyFourHours.total shouldBe 2
         report.twentyFourHours.versionCounts() shouldBe mapOf(
-            "octi/1.0.0/FOSS" to 1,
-            "octi/2.0.0/GPLAY" to 1,
-            "octi/3.0.0/GPLAY" to 1,
+            "1.0.0" to 1,
+            "2.0.0" to 1,
         )
         report.twentyFourHours.buildFlavorCounts() shouldBe mapOf(
             "FOSS" to 1,
-            "GPLAY" to 2,
+            "GPLAY" to 1,
         )
     }
 
     @Test
     fun `report formats counts and percentages sorted by count`() {
-        val report = DeviceActivityReporter.buildReport(
-            devices = listOf(
-                device(version = "octi/1.0.0/FOSS", lastSeen = now),
-                device(version = "octi/1.0.0/FOSS", lastSeen = now),
-                device(version = "octi/2.0.0/GPLAY", lastSeen = now),
-            ),
-            activeDeviceKeys = emptySet(),
-            now = now,
+        val activity = mapOf(
+            randomKey() to TrackedActivity("octi/1.0.0/FOSS", seenAt = now),
+            randomKey() to TrackedActivity("octi/1.0.0/FOSS", seenAt = now),
+            randomKey() to TrackedActivity("octi/2.0.0/GPLAY", seenAt = now),
         )
+
+        val report = DeviceActivityReporter.buildReport(activity = activity, now = now)
 
         DeviceActivityReporter.formatReport(report) shouldBe
             """
@@ -66,37 +55,39 @@ class DeviceActivityReporterTest {
                   FOSS=2 (66.7%)
                   GPLAY=1 (33.3%)
                 versions:
-                  octi/1.0.0/FOSS=2 (66.7%)
-                  octi/2.0.0/GPLAY=1 (33.3%)
+                  1.0.0=2 (66.7%)
+                  2.0.0=1 (33.3%)
+                auth-failures: total=0
+                  <none>
               24h: total=3
                 flavors:
                   FOSS=2 (66.7%)
                   GPLAY=1 (33.3%)
                 versions:
-                  octi/1.0.0/FOSS=2 (66.7%)
-                  octi/2.0.0/GPLAY=1 (33.3%)
+                  1.0.0=2 (66.7%)
+                  2.0.0=1 (33.3%)
+                auth-failures: total=0
+                  <none>
             """.trimIndent()
     }
 
     @Test
-    fun `unknown versions are grouped and empty windows are safe`() {
-        val empty = DeviceActivityReporter.buildReport(
-            devices = emptyList(),
-            activeDeviceKeys = emptySet(),
-            now = now,
-        )
-        empty.oneHour.total shouldBe 0
-        empty.oneHour.versions shouldBe emptyList()
-        empty.oneHour.buildFlavors shouldBe emptyList()
+    fun `empty activity yields empty windows`() {
+        val report = DeviceActivityReporter.buildReport(activity = emptyMap(), now = now)
 
-        val report = DeviceActivityReporter.buildReport(
-            devices = listOf(
-                device(version = null, lastSeen = now),
-                device(version = "   ", lastSeen = now),
-            ),
-            activeDeviceKeys = emptySet(),
-            now = now,
+        report.oneHour.total shouldBe 0
+        report.oneHour.versions shouldBe emptyList()
+        report.oneHour.buildFlavors shouldBe emptyList()
+    }
+
+    @Test
+    fun `non-octi activity buckets as unknown for both version and flavor`() {
+        val activity = mapOf(
+            randomKey() to TrackedActivity("", seenAt = now),
+            randomKey() to TrackedActivity("", seenAt = now),
         )
+
+        val report = DeviceActivityReporter.buildReport(activity = activity, now = now)
 
         report.oneHour.versions shouldBe listOf(
             DeviceActivityReporter.VersionStats(
@@ -115,26 +106,24 @@ class DeviceActivityReporterTest {
     }
 
     @Test
-    fun `sanitized-equivalent versions are grouped together`() {
-        val report = DeviceActivityReporter.buildReport(
-            devices = listOf(
-                device(version = "octi/1.0.0", lastSeen = now),
-                device(version = "  octi/1.0.0  ", lastSeen = now),
-                device(version = null, lastSeen = now),
-                device(version = "\n\t", lastSeen = now),
-            ),
-            activeDeviceKeys = emptySet(),
-            now = now,
+    fun `equivalent octi user agents are grouped together`() {
+        val activity = mapOf(
+            randomKey() to TrackedActivity("octi/1.0.0/FOSS", seenAt = now),
+            randomKey() to TrackedActivity("octi/1.0.0/FOSS", seenAt = now),
+            randomKey() to TrackedActivity("", seenAt = now),
+            randomKey() to TrackedActivity("", seenAt = now),
         )
+
+        val report = DeviceActivityReporter.buildReport(activity = activity, now = now)
 
         report.oneHour.versions shouldBe listOf(
             DeviceActivityReporter.VersionStats(
-                version = "<unknown>",
+                version = "1.0.0",
                 count = 2,
                 percent = 50.0,
             ),
             DeviceActivityReporter.VersionStats(
-                version = "octi/1.0.0",
+                version = "<unknown>",
                 count = 2,
                 percent = 50.0,
             ),
@@ -153,12 +142,151 @@ class DeviceActivityReporterTest {
     }
 
     @Test
+    fun `app version is extracted from octi user-agent style versions`() {
+        DeviceActivityReporter.appVersionForLog("octi/1.0.0-beta0/FOSS/dev-54f6d23a") shouldBe "1.0.0-beta0"
+        DeviceActivityReporter.appVersionForLog("octi/0.11.2-rc0/GPLAY") shouldBe "0.11.2-rc0"
+        DeviceActivityReporter.appVersionForLog("1.0.0-beta0") shouldBe "1.0.0-beta0"
+        DeviceActivityReporter.appVersionForLog("octi/") shouldBe "<unknown>"
+        DeviceActivityReporter.appVersionForLog(null) shouldBe "<unknown>"
+    }
+
+    @Test
     fun `build flavor is parsed from user-agent style versions`() {
         DeviceActivityReporter.buildFlavorForLog("octi/1.2.3/FOSS") shouldBe "FOSS"
+        DeviceActivityReporter.buildFlavorForLog("octi/0.11.2-rc0/GPLAY") shouldBe "GPLAY"
+        DeviceActivityReporter.buildFlavorForLog("octi/0.13.0-rc0/FOSS") shouldBe "FOSS"
         DeviceActivityReporter.buildFlavorForLog("octi/1.2.3/gplay/dev-a1b2c3d") shouldBe "GPLAY"
         DeviceActivityReporter.buildFlavorForLog("octi/1.2.3/GPLATE") shouldBe "GPLAY"
         DeviceActivityReporter.buildFlavorForLog("1.2.3") shouldBe "<unknown>"
         DeviceActivityReporter.buildFlavorForLog(null) shouldBe "<unknown>"
+    }
+
+    @Test
+    fun `tracked octi user agent with unknown flavor is kept but grouped as unknown flavor`() {
+        val activity = mapOf(
+            randomKey() to TrackedActivity("octi/1.0.0-beta0/MODDED/dev-d0a81273", seenAt = now),
+        )
+
+        val report = DeviceActivityReporter.buildReport(activity = activity, now = now)
+
+        report.oneHour.versionCounts() shouldBe mapOf("1.0.0-beta0" to 1)
+        report.oneHour.buildFlavorCounts() shouldBe mapOf("<unknown>" to 1)
+    }
+
+    @Test
+    fun `auth-failure section is empty when no failures occurred`() {
+        val report = DeviceActivityReporter.buildReport(activity = emptyMap(), now = now)
+
+        report.oneHour.authFailures.total shouldBe 0
+        report.oneHour.authFailures.byReason shouldBe emptyList()
+    }
+
+    @Test
+    fun `auth-failure section groups by reason then by user agent`() {
+        val failures = listOf(
+            AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "bad-credentials", "octi/1.0.0/FOSS"),
+            AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "bad-credentials", "octi/1.0.0/FOSS"),
+            AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "bad-credentials", "ktor-client"),
+            AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "unknown-device", "octi/0.9.0/GPLAY"),
+        )
+
+        val report = DeviceActivityReporter.buildReport(
+            activity = emptyMap(),
+            failures = failures,
+            now = now,
+        )
+
+        report.oneHour.authFailures.total shouldBe 4
+        report.oneHour.authFailures.byReason.map { it.reasonTag to it.count } shouldBe listOf(
+            "bad-credentials" to 3,
+            "unknown-device" to 1,
+        )
+        report.oneHour.authFailures.byReason[0].topUserAgents shouldBe listOf(
+            DeviceActivityReporter.UserAgentCount("octi/1.0.0/FOSS", 2),
+            DeviceActivityReporter.UserAgentCount("ktor-client", 1),
+        )
+        report.oneHour.authFailures.byReason[1].topUserAgents shouldBe listOf(
+            DeviceActivityReporter.UserAgentCount("octi/0.9.0/GPLAY", 1),
+        )
+    }
+
+    @Test
+    fun `auth-failure section excludes events older than the window`() {
+        val failures = listOf(
+            AuthFailureEvent(now.minus(Duration.ofMinutes(30)), "bad-credentials", "octi/1.0.0/FOSS"),
+            AuthFailureEvent(now.minus(Duration.ofHours(2)), "bad-credentials", "octi/1.0.0/FOSS"),
+        )
+
+        val report = DeviceActivityReporter.buildReport(
+            activity = emptyMap(),
+            failures = failures,
+            now = now,
+        )
+
+        report.oneHour.authFailures.total shouldBe 1
+        report.twentyFourHours.authFailures.total shouldBe 2
+    }
+
+    @Test
+    fun `auth-failure section caps top user agents per reason`() {
+        val failures = (1..10).flatMap { i ->
+            List(i) { AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "bad-credentials", "ua-$i") }
+        }
+
+        val report = DeviceActivityReporter.buildReport(
+            activity = emptyMap(),
+            failures = failures,
+            now = now,
+        )
+
+        val reason = report.oneHour.authFailures.byReason.single()
+        reason.count shouldBe failures.size
+        reason.topUserAgents.size shouldBe 5
+        reason.topUserAgents.first().userAgent shouldBe "ua-10"
+        reason.topUserAgents.last().userAgent shouldBe "ua-6"
+    }
+
+    @Test
+    fun `auth-failure formats with reason and ua breakdown`() {
+        val activity = mapOf(
+            randomKey() to TrackedActivity("octi/1.0.0/FOSS", seenAt = now),
+        )
+        val failures = listOf(
+            AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "bad-credentials", "octi/1.0.0/FOSS"),
+            AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "bad-credentials", "octi/1.0.0/FOSS"),
+            AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "missing-device-id", ""),
+        )
+
+        val report = DeviceActivityReporter.buildReport(
+            activity = activity,
+            failures = failures,
+            now = now,
+        )
+
+        DeviceActivityReporter.formatReport(report) shouldBe
+            """
+            device-stats:
+              1h: total=1
+                flavors:
+                  FOSS=1 (100.0%)
+                versions:
+                  1.0.0=1 (100.0%)
+                auth-failures: total=3
+                  bad-credentials=2
+                    octi/1.0.0/FOSS=2
+                  missing-device-id=1
+                    <unknown>=1
+              24h: total=1
+                flavors:
+                  FOSS=1 (100.0%)
+                versions:
+                  1.0.0=1 (100.0%)
+                auth-failures: total=3
+                  bad-credentials=2
+                    octi/1.0.0/FOSS=2
+                  missing-device-id=1
+                    <unknown>=1
+            """.trimIndent()
     }
 
     private fun DeviceActivityReporter.WindowStats.versionCounts(): Map<String, Int> {
@@ -169,22 +297,5 @@ class DeviceActivityReporterTest {
         return buildFlavors.associate { it.flavor to it.count }
     }
 
-    private fun device(
-        version: String?,
-        lastSeen: Instant,
-        accountId: UUID = UUID.randomUUID(),
-        deviceId: UUID = UUID.randomUUID(),
-    ): Device {
-        return Device(
-            data = Device.Data(
-                id = deviceId,
-                password = "test-password",
-                version = version,
-                addedAt = lastSeen,
-                lastSeen = lastSeen,
-            ),
-            path = Path.of("/tmp/$deviceId"),
-            accountId = accountId,
-        )
-    }
+    private fun randomKey(): DeviceKey = DeviceKey(UUID.randomUUID(), UUID.randomUUID())
 }

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceClientIdentityTrackerTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceClientIdentityTrackerTest.kt
@@ -1,0 +1,186 @@
+package eu.darken.octi.server.device
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+class DeviceClientIdentityTrackerTest {
+
+    private val key = DeviceKey(UUID.randomUUID(), UUID.randomUUID())
+    private val now: Instant = Instant.parse("2026-04-29T12:00:00Z")
+
+    @Test
+    fun `octi user agent is recorded with seenAt`() {
+        val tracker = DeviceClientIdentityTracker()
+        val userAgent = "octi/0.11.2-rc0/GPLAY"
+
+        tracker.recordUserAgent(key, userAgent, seenAt = now)
+
+        tracker.userAgentFor(key) shouldBe userAgent
+        tracker.snapshotActivity()[key] shouldBe DeviceClientIdentityTracker.TrackedActivity(
+            userAgent = userAgent,
+            seenAt = now,
+        )
+    }
+
+    @Test
+    fun `non-octi user agent records empty marker but tracks activity`() {
+        val tracker = DeviceClientIdentityTracker()
+
+        tracker.recordUserAgent(key, "modded-client/1.0/FOSS", seenAt = now)
+
+        tracker.userAgentFor(key) shouldBe null
+        tracker.snapshotActivity()[key] shouldBe DeviceClientIdentityTracker.TrackedActivity(
+            userAgent = "",
+            seenAt = now,
+        )
+    }
+
+    @Test
+    fun `non-octi update preserves previous octi user agent but bumps seenAt`() {
+        val tracker = DeviceClientIdentityTracker()
+        val initialAt = now
+        val later = now.plus(Duration.ofMinutes(10))
+
+        tracker.recordUserAgent(key, "octi/0.13.0/FOSS", seenAt = initialAt)
+        tracker.recordUserAgent(key, "ktor-client", seenAt = later)
+
+        tracker.userAgentFor(key) shouldBe "octi/0.13.0/FOSS"
+        tracker.snapshotActivity()[key] shouldBe DeviceClientIdentityTracker.TrackedActivity(
+            userAgent = "octi/0.13.0/FOSS",
+            seenAt = later,
+        )
+    }
+
+    @Test
+    fun `octi update overwrites previous user agent and bumps seenAt`() {
+        val tracker = DeviceClientIdentityTracker()
+        val initialAt = now
+        val later = now.plus(Duration.ofMinutes(10))
+
+        tracker.recordUserAgent(key, "octi/0.13.0/FOSS", seenAt = initialAt)
+        tracker.recordUserAgent(key, "octi/0.14.0/GPLAY", seenAt = later)
+
+        tracker.snapshotActivity()[key] shouldBe DeviceClientIdentityTracker.TrackedActivity(
+            userAgent = "octi/0.14.0/GPLAY",
+            seenAt = later,
+        )
+    }
+
+    @Test
+    fun `retaining known devices prunes stale identities`() {
+        val tracker = DeviceClientIdentityTracker()
+        val staleKey = DeviceKey(UUID.randomUUID(), UUID.randomUUID())
+
+        tracker.recordUserAgent(key, "octi/0.13.0-rc0/FOSS", seenAt = now)
+        tracker.recordUserAgent(staleKey, "octi/0.16.0-rc0/GPLAY", seenAt = now)
+        tracker.retainDevices(setOf(key))
+
+        tracker.snapshotActivity().keys shouldBe setOf(key)
+    }
+
+    @Test
+    fun `auth failure is recorded with reason and user agent`() {
+        val tracker = DeviceClientIdentityTracker()
+
+        tracker.recordAuthFailure("bad-credentials", "octi/1.0.0/FOSS", seenAt = now)
+
+        val snapshot = tracker.snapshotAuthFailures(now)
+        snapshot.size shouldBe 1
+        snapshot[0] shouldBe DeviceClientIdentityTracker.AuthFailureEvent(
+            seenAt = now,
+            reasonTag = "bad-credentials",
+            userAgent = "octi/1.0.0/FOSS",
+        )
+    }
+
+    @Test
+    fun `auth failure with non-octi user agent is recorded verbatim`() {
+        val tracker = DeviceClientIdentityTracker()
+
+        tracker.recordAuthFailure("missing-credentials", "ktor-client", seenAt = now)
+
+        tracker.snapshotAuthFailures(now)[0].userAgent shouldBe "ktor-client"
+    }
+
+    @Test
+    fun `auth failure with blank user agent records empty marker`() {
+        val tracker = DeviceClientIdentityTracker()
+
+        tracker.recordAuthFailure("missing-device-id", null, seenAt = now)
+
+        tracker.snapshotAuthFailures(now)[0].userAgent shouldBe ""
+    }
+
+    @Test
+    fun `auth failures older than 24h are lazily pruned on snapshot`() {
+        val tracker = DeviceClientIdentityTracker()
+        val tooOld = now.minus(Duration.ofHours(25))
+        val recent = now.minus(Duration.ofHours(1))
+
+        tracker.recordAuthFailure("bad-credentials", "octi/1.0.0/FOSS", seenAt = tooOld)
+        tracker.recordAuthFailure("bad-credentials", "octi/1.0.0/FOSS", seenAt = recent)
+
+        val snapshot = tracker.snapshotAuthFailures(now)
+        snapshot.size shouldBe 1
+        snapshot[0].seenAt shouldBe recent
+    }
+
+    @Test
+    fun `out-of-order stale events are pruned from the middle on snapshot`() {
+        val tracker = DeviceClientIdentityTracker()
+
+        tracker.recordAuthFailure("bad-credentials", "recent-1", seenAt = now.minus(Duration.ofHours(1)))
+        tracker.recordAuthFailure("bad-credentials", "stale", seenAt = now.minus(Duration.ofHours(25)))
+        tracker.recordAuthFailure("bad-credentials", "recent-2", seenAt = now.minus(Duration.ofMinutes(5)))
+
+        val snapshot = tracker.snapshotAuthFailures(now)
+        snapshot.map { it.userAgent } shouldBe listOf("recent-1", "recent-2")
+    }
+
+    @Test
+    fun `auth failure deque caps at MAX_FAILURE_EVENTS`() {
+        val tracker = DeviceClientIdentityTracker()
+        val cap = DeviceClientIdentityTracker.MAX_FAILURE_EVENTS
+
+        repeat(cap + 5) { i ->
+            tracker.recordAuthFailure("bad-credentials", "ua-$i", seenAt = now.plusMillis(i.toLong()))
+        }
+
+        val snapshot = tracker.snapshotAuthFailures(now.plusMillis((cap + 5).toLong()))
+        snapshot.size shouldBe cap
+        snapshot.first().userAgent shouldBe "ua-5"
+        snapshot.last().userAgent shouldBe "ua-${cap + 4}"
+    }
+
+    @Test
+    fun `concurrent auth failure inserts respect cap and produce a clean snapshot`() {
+        val tracker = DeviceClientIdentityTracker()
+        val threadCount = 8
+        val perThread = 2_000
+        val pool = java.util.concurrent.Executors.newFixedThreadPool(threadCount)
+
+        try {
+            val tasks = (0 until threadCount).map { t ->
+                java.util.concurrent.Callable {
+                    repeat(perThread) { i ->
+                        tracker.recordAuthFailure(
+                            reasonTag = "bad-credentials",
+                            rawUserAgent = "ua-$t-$i",
+                            seenAt = now.plusMillis((t * perThread + i).toLong()),
+                        )
+                    }
+                }
+            }
+            pool.invokeAll(tasks).forEach { it.get() }
+        } finally {
+            pool.shutdown()
+        }
+
+        val snapshot = tracker.snapshotAuthFailures(now.plusMillis((threadCount * perThread).toLong()))
+        (snapshot.size <= DeviceClientIdentityTracker.MAX_FAILURE_EVENTS) shouldBe true
+        snapshot.all { it.reasonTag == "bad-credentials" } shouldBe true
+    }
+}

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceFlowTest.kt
@@ -167,6 +167,33 @@ class DeviceFlowTest : TestRunner() {
     }
 
     @Test
+    fun `debug user agent does not replace device version at registration`() = runTest2 {
+        val userAgent = "octi/1.0.0-beta0/FOSS/dev-d0a81273"
+        val creds = createDevice(version = "1.0.0-beta0", userAgent = userAgent)
+        val device = getDevices(creds).devices.single()
+        val key = DeviceKey(UUID.fromString(creds.account), creds.deviceId)
+
+        device.version shouldBe "1.0.0-beta0"
+        component.deviceClientIdentityTracker().userAgentFor(key) shouldBe userAgent
+    }
+
+    @Test
+    fun `debug user agent tracked on authenticated request without replacing version`() = runTest2 {
+        val userAgent = "octi/1.0.0-beta0/GPLAY/dev-d0a81273"
+        val creds = createDevice(version = "1.0.0-beta0")
+        val key = DeviceKey(UUID.fromString(creds.account), creds.deviceId)
+
+        http.get("/v1/devices") {
+            addCredentials(creds)
+            headers.append("Octi-Device-Version", "1.0.0-beta0")
+            headers.set(HttpHeaders.UserAgent, userAgent)
+        }
+
+        getDevices(creds).devices.single().version shouldBe "1.0.0-beta0"
+        component.deviceClientIdentityTracker().userAgentFor(key) shouldBe userAgent
+    }
+
+    @Test
     fun `platform stored at registration`() = runTest2 {
         val creds = createDevice(platform = "android")
         val device = getDevices(creds).devices.single()
@@ -243,6 +270,62 @@ class DeviceFlowTest : TestRunner() {
         }
 
         getDevices(creds).devices.single().platform shouldBe "desktop"
+    }
+
+    @Test
+    fun `auth failure with missing X-Device-ID is tracked`() = runTest2 {
+        http.get(endPoint).apply {
+            status shouldBe HttpStatusCode.BadRequest
+        }
+
+        val failures = component.deviceClientIdentityTracker().snapshotAuthFailures()
+        failures.size shouldBe 1
+        failures[0].reasonTag shouldBe "missing-device-id"
+        failures[0].userAgent shouldBe "ktor-client"
+    }
+
+    @Test
+    fun `auth failure with missing credentials is tracked`() = runTest2 {
+        val creds = createDevice()
+
+        http.get(endPoint) {
+            addDeviceId(creds.deviceId)
+        }.apply {
+            status shouldBe HttpStatusCode.BadRequest
+        }
+
+        val failures = component.deviceClientIdentityTracker().snapshotAuthFailures()
+        failures.any { it.reasonTag == "missing-credentials" } shouldBe true
+    }
+
+    @Test
+    fun `auth failure with unknown device is tracked`() = runTest2 {
+        val creds = createDevice()
+
+        http.get(endPoint) {
+            addDeviceId(UUID.randomUUID())
+            addAuth(creds.auth)
+        }.apply {
+            status shouldBe HttpStatusCode.NotFound
+        }
+
+        val failures = component.deviceClientIdentityTracker().snapshotAuthFailures()
+        failures.any { it.reasonTag == "unknown-device" } shouldBe true
+    }
+
+    @Test
+    fun `auth failure with bad password is tracked`() = runTest2 {
+        val creds = createDevice()
+
+        http.get(endPoint) {
+            addDeviceId(creds.deviceId)
+            addAuth(Auth(creds.account, "wrong-password"))
+        }.apply {
+            status shouldBe HttpStatusCode.Unauthorized
+        }
+
+        val failures = component.deviceClientIdentityTracker().snapshotAuthFailures()
+        failures.any { it.reasonTag == "bad-credentials" } shouldBe true
     }
 
     @Test

--- a/src/test/kotlin/eu/darken/octi/server/ws/WsFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/ws/WsFlowTest.kt
@@ -3,6 +3,7 @@ package eu.darken.octi.server.ws
 import eu.darken.octi.*
 import eu.darken.octi.server.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.server.common.debug.logging.log
+import eu.darken.octi.server.device.DeviceKey
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -30,8 +31,10 @@ import kotlin.io.path.deleteRecursively
 class WsFlowTest : TestRunner() {
 
     /** Like runTest2 but uses runBlocking — WebSocket tests need real time, not virtual time */
-    private fun runWsTest(test: suspend TestEnvironment.() -> Unit) {
-        val appConfig = baseConfig.copy(port = 16024)
+    private fun runWsTest(
+        appConfig: eu.darken.octi.server.App.Config = baseConfig.copy(port = 16024),
+        test: suspend TestEnvironment.() -> Unit,
+    ) {
         Files.createDirectories(appConfig.dataPath)
         val component = eu.darken.octi.server.App.createComponent(appConfig)
         val app = component.application()
@@ -84,6 +87,68 @@ class WsFlowTest : TestRunner() {
     }
 
     @Test
+    fun `connect records debug user agent`() = runWsTest {
+        val userAgent = "octi/1.0.0-beta0/FOSS/dev-d0a81273"
+        val creds = createDevice(version = "1.0.0-beta0")
+        val key = DeviceKey(UUID.fromString(creds.account), creds.deviceId)
+        val wsClient = createWsClient()
+
+        wsClient.webSocket(
+            urlString = wsUrl(),
+            request = {
+                addCredentials(creds)
+                headers.set(HttpHeaders.UserAgent, userAgent)
+            },
+        ) {
+            close(CloseReason(CloseReason.Codes.NORMAL, "Test done"))
+        }
+
+        component.deviceClientIdentityTracker().userAgentFor(key) shouldBe userAgent
+        wsClient.close()
+    }
+
+    @Test
+    fun `rate-limited authenticated connect still records client identity`() = runWsTest(
+        appConfig = baseConfig.copy(
+            port = 16024,
+            accountRateLimit = 1,
+            accountRateLimitWindowSeconds = 60,
+        ),
+    ) {
+        val firstUserAgent = "octi/1.0.0/FOSS"
+        val overLimitUserAgent = "octi/2.0.0/GPLAY"
+        val creds = createDevice(version = "1.0.0")
+        val key = DeviceKey(UUID.fromString(creds.account), creds.deviceId)
+        val wsClient = createWsClient()
+
+        wsClient.webSocket(
+            urlString = wsUrl(),
+            request = {
+                addCredentials(creds)
+                headers.set(HttpHeaders.UserAgent, firstUserAgent)
+            },
+        ) {
+            close(CloseReason(CloseReason.Codes.NORMAL, "Test done"))
+        }
+
+        var closedWithRateLimit = false
+        wsClient.webSocket(
+            urlString = wsUrl(),
+            request = {
+                addCredentials(creds)
+                headers.set(HttpHeaders.UserAgent, overLimitUserAgent)
+            },
+        ) {
+            val reason = closeReason.await()
+            if (reason?.code == CloseReason.Codes.TRY_AGAIN_LATER.code) closedWithRateLimit = true
+        }
+
+        closedWithRateLimit shouldBe true
+        component.deviceClientIdentityTracker().userAgentFor(key) shouldBe overLimitUserAgent
+        wsClient.close()
+    }
+
+    @Test
     fun `connect without credentials fails`() = runWsTest {
         val wsClient = createWsClient()
 
@@ -114,6 +179,19 @@ class WsFlowTest : TestRunner() {
         }
         closedWithPolicy shouldBe true
         wsClient.close()
+    }
+
+    @Test
+    fun `WS auth failure is tracked with reason and user agent`() = runWsTest {
+        val wsClient = createWsClient()
+
+        wsClient.webSocket(urlString = wsUrl()) {
+            closeReason.await()
+        }
+        wsClient.close()
+
+        val failures = component.deviceClientIdentityTracker().snapshotAuthFailures()
+        failures.any { it.reasonTag == "missing-device-id" } shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Make `DeviceClientIdentityTracker` the sole source for the 1h/24h device-activity report. The reporter no longer reads `device.lastSeen`, `device.version`, or `ConnectionRegistry` — it builds windows from tracker `seenAt` instead. Post-restart the report shows what this server instance has actually observed.
- Track every authenticated request (octi UAs verbatim, non-octi as an empty marker so they bucket as `<unknown>`). Record client identity immediately after auth succeeds, before the per-account rate-limit gate, so legitimately over-limit devices stay visible. Persisted `device.lastSeen` / IP-tracker churn is still gated behind the rate limiter.
- Add an auth-failure stream: every `AuthResult.Failure` from `verifyCaller` and `WsRoute` lands in a capped (10k), 24h-windowed deque, tagged with stable reasons (`missing-device-id`, `missing-credentials`, `unknown-device`, `bad-credentials`). Reporter logs a per-window reason × top-5 UA matrix.

## Test plan
- [x] Tracker unit tests: octi/non-octi/non-octi-update record semantics, retain prune, failure record + out-of-order 24h prune, cap eviction, concurrent insert.
- [x] Rewritten `DeviceActivityReporterTest` for the tracker-driven signature, including auth-failure section formatting.
- [x] `AuthenticateDeviceTest` tag assertions plus parse-collapse cases (blank/malformed device-id, non-Basic auth, invalid base64, payload without colon, non-UUID account).
- [x] HTTP/WS integration tests for auth-failure tracking and "rate-limited successful auth still records identity".
- [x] `./gradlew check` green.
