### PR TITLE
feat: add CI-driven release pipeline

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,3 +16,4 @@ Sync server for the [Octi](https://github.com/d4rken-org/octi) Android app. Devi
 - [Build Commands](rules/build-commands.md) — Gradle commands, running locally, Docker, CI
 - [Testing](rules/testing.md) — TestRunner, integration tests, helpers
 - [Commit Guidelines](rules/commit-guidelines.md) — Commit message format and examples
+- [Releasing](rules/release.md) — Release flow, inputs, gotchas, recovery

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -1,0 +1,64 @@
+# Releasing
+
+## Flow at a glance
+
+```
+release-prepare.yml (workflow_dispatch)
+  └─ Job 1: compute-and-validate  (always)
+       reads gradle.properties version=, computes next, checks tag collision, writes summary
+  └─ Job 2: push-and-dispatch  (only when dry_run=false)
+       mints App token, bumps gradle.properties, commits "Release: vX.Y.Z", tags, atomic push
+           │
+           └─► release-tag.yml fires automatically from the App-token push
+                 └─ Job 1: validate-tag  (always)
+                      regex check on tag name + gradle.properties consistency
+                 └─ Job 2: release-github  (needs validate-tag, gated by foss-production)
+                      multi-arch Docker push to ghcr.io + installDist zip + GitHub Release
+```
+
+## Inputs for `release-prepare.yml`
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `bump_type` | choice (patch/minor/major) | `patch` | Auto-increment strategy. Ignored when `version` is set. |
+| `version` | string | `''` | Explicit version override (e.g. `1.1.0`, `2.0.0-rc1`). Ignores `bump_type`. |
+| `expected_current` | string | `''` | Safety check: fail if `gradle.properties` version doesn't match. Defends against concurrent queued runs. |
+| `dry_run` | boolean | `true` | When true, only Job 1 runs (validate + print plan). Set to `false` to actually push. |
+
+Examples:
+- Normal patch release: `bump_type=patch`, `dry_run=false`
+- First RC: `version=1.1.0-rc1`, `dry_run=false`
+- Promote RC to stable: `version=1.1.0`, `dry_run=false`
+
+## Version source of truth
+
+`gradle.properties` — the single `version=X.Y.Z` line. Gradle reads it automatically; `build.gradle.kts` does not set `version`.
+
+## Cancel window
+
+When `dry_run=false`, Job 1 ends (summary appears on screen) and Job 2 starts runner spin-up (~5–15 seconds). That window is the manual-cancel affordance — watch the run page after dispatching. Job 1's validation catches most issues before Job 2 starts.
+
+## Five gotchas worth memorizing
+
+1. **App-token pushes fire `on: push: tags`** — do NOT add `gh workflow run release-tag.yml`. App tokens aren't `GITHUB_TOKEN`, so they fire workflow triggers. Adding an explicit dispatch produces duplicate runs (capod #568).
+2. **Use `app-slug` output, not `gh api /app`** — `/app` requires a signed App JWT, not the installation token; it 401s (capod #567).
+3. **Use `client-id`, not `app-id`** — `app-id` is deprecated upstream and prints warnings. Secret name is `RELEASE_APP_CLIENT_ID` (capod #569).
+4. **Atomic push** — `git push --atomic origin HEAD:refs/heads/main "refs/tags/vX.Y.Z"`. Both the bump commit and the tag land together or neither does.
+5. **`workflow_dispatch` only sees workflows on the default branch** — merging to `main` is required before you can dispatch `release-prepare.yml`.
+
+## Recovery procedures
+
+**Build failure after tag push** (Docker/GH Release step failed, tag exists, gradle.properties already bumped):
+1. Go to `release-tag.yml` → Run workflow → target the tag ref (e.g. `v1.0.1`), set `dry_run=false`.
+2. `validate-tag` re-checks format + consistency. `release-github` re-runs with `foss-production` approval.
+
+**Needs rollback** (tag pushed but you want to undo before the release is published):
+1. Delete the remote tag: `git push origin --delete vX.Y.Z`
+2. Revert the bump commit on `main` (or cherry-pick a revert): `git revert <sha>` + push.
+3. Re-cut from the correct state.
+
+## Prerequisites (one-time setup)
+
+- `d4rken-org-releaser` GitHub App installed on this repo (already used by capod).
+- Org secrets `RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY` accessible to this repo.
+- App added as bypass actor in any branch/tag protection rulesets covering `main` and `v*` tags (`GITHUB_TOKEN` cannot be a bypass actor — only installed Apps can).

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,258 @@
+name: Release prepare
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type (ignored when version is set)'
+        required: false
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      version:
+        description: 'Explicit version override, e.g. 1.2.3 or 1.2.3-rc1 (ignores bump_type)'
+        required: false
+        default: ''
+        type: string
+      expected_current:
+        description: 'Safety check: fail if gradle.properties version does not match this value'
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: 'Dry run: validate and print plan only, skip commit/push'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-prepare-main
+  cancel-in-progress: false
+
+jobs:
+  compute-and-validate:
+    name: Compute and validate
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    outputs:
+      current_name: ${{ steps.read-version.outputs.current }}
+      new_name: ${{ steps.compute-version.outputs.new }}
+
+    steps:
+      - name: Guard — must run on main
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF" != "refs/heads/main" ]]; then
+            echo "::error::This workflow must be dispatched from main (got $REF)"
+            exit 1
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Read current version
+        id: read-version
+        env:
+          EXPECTED_CURRENT: ${{ inputs.expected_current }}
+        run: |
+          set -euo pipefail
+          count=$(grep -cE '^version=' gradle.properties || true)
+          [[ "$count" == "1" ]] || { echo "::error::expected exactly one 'version=' line in gradle.properties, found $count"; exit 1; }
+          current=$(awk -F= '$1=="version"{print $2}' gradle.properties)
+          echo "$current" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(rc|beta)(0|[1-9][0-9]*))?$' || {
+            echo "::error::current version '$current' does not match semver format"
+            exit 1
+          }
+          if [[ -n "$EXPECTED_CURRENT" && "$current" != "$EXPECTED_CURRENT" ]]; then
+            echo "::error::current version '$current' does not match expected_current '$EXPECTED_CURRENT'"
+            exit 1
+          fi
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        id: compute-version
+        env:
+          CURRENT: ${{ steps.read-version.outputs.current }}
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          OVERRIDE: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          new=$(python3 - <<'PYEOF'
+          import re, sys, os
+          semver = re.compile(r'^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(rc|beta)(0|[1-9][0-9]*))?$')
+          def parse(v):
+              m = semver.match(v)
+              if not m: sys.exit(f"invalid version: {v}")
+              return (int(m[1]), int(m[2]), int(m[3]), m[4], int(m[5]) if m[5] else None)
+          def precedence(p):
+              return (p[0], p[1], p[2], 1 if p[3] is None else 0, p[3] or '', p[4] or 0)
+          cur = parse(os.environ['CURRENT'])
+          override = os.environ.get('OVERRIDE') or None
+          if override:
+              nxt = parse(override)
+          else:
+              if cur[3] is not None:
+                  sys.exit("bump_type rejected on prerelease current; use explicit version override")
+              x, y, z = cur[:3]
+              b = os.environ['BUMP_TYPE']
+              if   b == 'patch': z += 1
+              elif b == 'minor': y, z = y + 1, 0
+              elif b == 'major': x, y, z = x + 1, 0, 0
+              else: sys.exit(f"invalid bump_type: {b}")
+              nxt = (x, y, z, None, None)
+          if precedence(nxt) <= precedence(cur):
+              sys.exit(f"refusing downgrade: {nxt} not > {cur}")
+          pre = f"-{nxt[3]}{nxt[4]}" if nxt[3] else ''
+          print(f"{nxt[0]}.{nxt[1]}.{nxt[2]}{pre}")
+          PYEOF
+          )
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+
+      - name: Check tag collision
+        env:
+          NEW: ${{ steps.compute-version.outputs.new }}
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify "refs/tags/v${NEW}" >/dev/null 2>&1; then
+            echo "::error::Local tag v${NEW} already exists"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v${NEW}" >/dev/null; then
+            echo "::error::Remote tag v${NEW} already exists"
+            exit 1
+          fi
+
+      - name: Write job summary
+        env:
+          CURRENT: ${{ steps.read-version.outputs.current }}
+          NEW: ${{ steps.compute-version.outputs.new }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          echo "| Field    | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Current  | \`$CURRENT\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| New      | \`$NEW\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Tag      | \`v$NEW\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Dry run  | \`$DRY_RUN\` |" >> "$GITHUB_STEP_SUMMARY"
+
+  push-and-dispatch:
+    name: Push bump and tag
+    needs: compute-and-validate
+    if: ${{ !inputs.dry_run }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 #v3.1.1
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Resolve bot identity
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          user_id=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+          echo "user_name=${APP_SLUG}[bot]" >> "$GITHUB_OUTPUT"
+          echo "user_email=${user_id}+${APP_SLUG}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main with App token
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Re-validate current version
+        env:
+          EXPECTED: ${{ needs.compute-and-validate.outputs.current_name }}
+        run: |
+          set -euo pipefail
+          count=$(grep -cE '^version=' gradle.properties || true)
+          [[ "$count" == "1" ]] || { echo "::error::expected exactly one 'version=' line, found $count"; exit 1; }
+          current=$(awk -F= '$1=="version"{print $2}' gradle.properties)
+          [[ "$current" == "$EXPECTED" ]] || {
+            echo "::error::current version '$current' does not match expected '$EXPECTED' (main moved during job gap?)"
+            exit 1
+          }
+
+      - name: Re-check tag collision
+        env:
+          NEW: ${{ needs.compute-and-validate.outputs.new_name }}
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify "refs/tags/v${NEW}" >/dev/null 2>&1; then
+            echo "::error::Local tag v${NEW} already exists"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v${NEW}" >/dev/null; then
+            echo "::error::Remote tag v${NEW} already exists"
+            exit 1
+          fi
+
+      - name: Apply version bump
+        env:
+          NEW: ${{ needs.compute-and-validate.outputs.new_name }}
+        run: |
+          set -euo pipefail
+          sed -i "s/^version=.*/version=${NEW}/" gradle.properties
+          count=$(grep -cE '^version=' gradle.properties || true)
+          [[ "$count" == "1" ]] || { echo "::error::expected exactly one version= line after bump, found $count"; exit 1; }
+          got=$(awk -F= '$1=="version"{print $2}' gradle.properties)
+          [[ "$got" == "$NEW" ]] || { echo "::error::bump verification failed: expected '$NEW' got '$got'"; exit 1; }
+
+      - name: Configure git identity
+        env:
+          GIT_USER_NAME: ${{ steps.bot.outputs.user_name }}
+          GIT_USER_EMAIL: ${{ steps.bot.outputs.user_email }}
+        run: |
+          set -euo pipefail
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
+
+      - name: Commit and tag
+        env:
+          NEW: ${{ needs.compute-and-validate.outputs.new_name }}
+        run: |
+          set -euo pipefail
+          git add gradle.properties
+          git commit -m "Release: v${NEW}"
+          git tag -a "v${NEW}" -m "Release v${NEW}"
+
+      - name: Atomic push
+        env:
+          NEW: ${{ needs.compute-and-validate.outputs.new_name }}
+        run: |
+          set -euo pipefail
+          git push --atomic origin HEAD:refs/heads/main "refs/tags/v${NEW}"
+
+      - name: Write final summary
+        env:
+          NEW: ${{ needs.compute-and-validate.outputs.new_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Pushed commit and tag \`v${NEW}\` to main." >> "$GITHUB_STEP_SUMMARY"
+          echo "The \`release-tag.yml\` workflow fired automatically — track it at:" >> "$GITHUB_STEP_SUMMARY"
+          echo "https://github.com/${REPO}/actions/workflows/release-tag.yml" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,12 +4,60 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run: validate tag only, skip publish (default true)'
+        required: false
+        default: true
+        type: boolean
 
-permissions: {}
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
+  validate-tag:
+    name: Validate tag
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check tag format
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "$TAG" | grep -qE '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(rc|beta)(0|[1-9][0-9]*))?$' || {
+            echo "::error::Tag '$TAG' does not match expected format vX.Y.Z[-rcN|-betaN]. Releases must be cut via the 'Release prepare' workflow."
+            exit 1
+          }
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check gradle.properties version matches tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          count=$(grep -cE '^version=' gradle.properties || true)
+          [[ "$count" == "1" ]] || { echo "::error::expected exactly one 'version=' line in gradle.properties, found $count"; exit 1; }
+          file_version=$(awk -F= '$1=="version"{print $2}' gradle.properties)
+          tag_version="${TAG#v}"
+          [[ "$file_version" == "$tag_version" ]] || {
+            echo "::error::gradle.properties version '$file_version' does not match tag '$TAG'. Releases must be cut via the 'Release prepare' workflow."
+            exit 1
+          }
+
   release-github:
     name: Create GitHub release
+    needs: [validate-tag]
+    if: "github.event_name != 'workflow_dispatch' || !inputs.dry_run"
     permissions:
       contents: write
       packages: write
@@ -71,7 +119,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda #v3.0.0
         with:
-          prerelease: ${{ contains(github.ref_name, '-beta') }}
+          prerelease: ${{ contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           generate_release_notes: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 }
 
 group = "eu.darken"
-version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+version=1.0.0


### PR DESCRIPTION
## Summary

- **** (new): -only, two-job pipeline. Job 1 reads , validates semver, checks tag collision (local + remote), prints a plan. Job 2 (skipped when ) mints a GitHub App token, bumps the version, commits , tags, and atomic-pushes — which fires  automatically.
- **** (modified): adds  job (regex +  consistency check), concurrency lock,  with  input for re-triggering a failed publish, fixes the prerelease flag to include `-rc` tags.
- ****: adds  as the single source of truth (replaces the stale  in ).

## Prerequisites before first dispatch

1. `d4rken-org-releaser` GitHub App installed on this repo.
2. Org secrets `RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY` accessible here.
3. App added as bypass actor in any branch/tag protection rulesets on `main`/`v*`.

## Test plan

- [ ] Merge to `main` (required — `workflow_dispatch` only finds workflows on the default branch)
- [ ] Dispatch `release-prepare.yml` with `dry_run=true` (default): Job 1 prints the version plan, Job 2 is skipped
- [ ] Dispatch with `dry_run=false`, `bump_type=patch`: verify single `release-tag.yml` run fires (no duplicate from explicit dispatch), `validate-tag` passes, `foss-production` approval gates publish