### PR TITLE
Reduce sync stats reporting frequency

### DIFF
--- a/src/main/kotlin/eu/darken/octi/server/ws/SyncNotifier.kt
+++ b/src/main/kotlin/eu/darken/octi/server/ws/SyncNotifier.kt
@@ -168,7 +168,7 @@ class SyncNotifier @Inject constructor(
 
     companion object {
         private const val DEBOUNCE_MS = 500L
-        private val STATS_INTERVAL: Duration = Duration.ofMinutes(1)
+        private val STATS_INTERVAL: Duration = Duration.ofMinutes(5)
         private val TAG = logTag("WS", "SyncNotifier")
     }
 }


### PR DESCRIPTION
Summary: Change sync notification stats reporting from every 1 minute to every 5 minutes while keeping empty windows silent. Testing: ./gradlew test --tests eu.darken.octi.server.ws.SyncNotificationStatsTest --tests eu.darken.octi.server.ws.SyncNotifierTest