### PR TITLE
Tag auth failures by source and missing-device reason

### DIFF
--- a/src/main/kotlin/eu/darken/octi/server/common/HttpExtensions.kt
+++ b/src/main/kotlin/eu/darken/octi/server/common/HttpExtensions.kt
@@ -4,6 +4,7 @@ import eu.darken.octi.server.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.server.common.debug.logging.log
 import eu.darken.octi.server.common.debug.logging.logTag
 import eu.darken.octi.server.device.Device
+import eu.darken.octi.server.device.AUTH_FAILURE_SOURCE_HTTP
 import eu.darken.octi.server.device.DeviceClientIdentityTracker
 import eu.darken.octi.server.device.DeviceId
 import eu.darken.octi.server.device.DeviceKey
@@ -73,10 +74,11 @@ suspend fun authenticateDevice(
             status = HttpStatusCode.BadRequest,
         )
 
-    val device = deviceRepo.getDevice(DeviceKey(creds.accountId, deviceId))
+    val deviceKey = DeviceKey(creds.accountId, deviceId)
+    val device = deviceRepo.getDevice(deviceKey)
         ?: return AuthResult.Failure(
             reason = "Unknown device: $deviceId",
-            tag = "unknown-device",
+            tag = deviceRepo.classifyMissingDevice(deviceKey).tag,
             status = HttpStatusCode.NotFound,
         )
 
@@ -152,7 +154,11 @@ suspend fun RoutingContext.verifyCaller(tag: String, deviceRepo: DeviceRepo): De
         is AuthResult.Success -> result.device
         is AuthResult.Failure -> {
             log(tag, WARN) { "verifyAuth(): ${result.reason}" }
-            deviceClientIdentityTracker?.recordAuthFailure(result.tag, call.request.userAgent())
+            deviceClientIdentityTracker?.recordAuthFailure(
+                reasonTag = result.tag,
+                rawUserAgent = call.request.userAgent(),
+                source = AUTH_FAILURE_SOURCE_HTTP,
+            )
             call.respond(result.status, result.reason)
             return null
         }

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceActivityReporter.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceActivityReporter.kt
@@ -53,7 +53,13 @@ class DeviceActivityReporter @Inject constructor(
     data class ReasonBreakdown(
         val reasonTag: String,
         val count: Int,
+        val sources: List<SourceCount>,
         val topUserAgents: List<UserAgentCount>,
+    )
+
+    data class SourceCount(
+        val source: String,
+        val count: Int,
     )
 
     data class UserAgentCount(
@@ -89,11 +95,13 @@ class DeviceActivityReporter @Inject constructor(
         private const val UNKNOWN_VERSION = "<unknown>"
         private const val UNKNOWN_BUILD_FLAVOR = "<unknown>"
         private const val UNKNOWN_USER_AGENT = "<unknown>"
+        private const val UNKNOWN_SOURCE = "<unknown>"
         private const val MAX_VERSION_DISPLAY_LENGTH = 80
         private const val FAILURE_TOP_USER_AGENTS = 5
         private val CONTROL_CHARS = Regex("[\\p{Cntrl}]+")
         private val BUILD_FLAVOR_TOKEN_SEPARATOR = Regex("[^A-Za-z0-9]+")
         private val BUILD_FLAVOR_ORDER = listOf("FOSS", "GPLAY", UNKNOWN_BUILD_FLAVOR)
+        private val SOURCE_ORDER = listOf(AUTH_FAILURE_SOURCE_HTTP, AUTH_FAILURE_SOURCE_WS, UNKNOWN_SOURCE)
         private val TAG = logTag("Device", "Activity")
 
         internal fun buildReport(
@@ -167,6 +175,12 @@ class DeviceActivityReporter @Inject constructor(
                 ?: UNKNOWN_USER_AGENT
         }
 
+        private fun sourceLabel(raw: String): String {
+            return sanitizeForLog(raw)
+                ?.take(32)
+                ?: UNKNOWN_SOURCE
+        }
+
         private fun buildWindowStats(
             label: String,
             window: Duration,
@@ -225,6 +239,15 @@ class DeviceActivityReporter @Inject constructor(
             val byReason = windowed
                 .groupBy { it.reasonTag }
                 .map { (reason, events) ->
+                    val sourceCounts = events
+                        .groupingBy { sourceLabel(it.source) }
+                        .eachCount()
+                        .entries
+                        .map { SourceCount(it.key, it.value) }
+                        .sortedWith(compareBy<SourceCount> {
+                            SOURCE_ORDER.indexOf(it.source).takeIf { index -> index >= 0 } ?: Int.MAX_VALUE
+                        }.thenBy { it.source })
+
                     val topUserAgents = events
                         .groupingBy { userAgentLabel(it.userAgent) }
                         .eachCount()
@@ -232,7 +255,12 @@ class DeviceActivityReporter @Inject constructor(
                         .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
                         .take(FAILURE_TOP_USER_AGENTS)
                         .map { UserAgentCount(it.key, it.value) }
-                    ReasonBreakdown(reasonTag = reason, count = events.size, topUserAgents = topUserAgents)
+                    ReasonBreakdown(
+                        reasonTag = reason,
+                        count = events.size,
+                        sources = sourceCounts,
+                        topUserAgents = topUserAgents,
+                    )
                 }
                 .sortedWith(compareByDescending<ReasonBreakdown> { it.count }.thenBy { it.reasonTag })
             return AuthFailureStats(total = windowed.size, byReason = byReason)
@@ -258,11 +286,16 @@ class DeviceActivityReporter @Inject constructor(
                 return
             }
             stats.byReason.forEach { reason ->
-                appendLine("      ${reason.reasonTag}=${reason.count}")
+                appendLine("      ${reason.reasonTag}=${reason.count}${reason.sources.formatSourceCounts()}")
                 reason.topUserAgents.forEach { ua ->
                     appendLine("        ${ua.userAgent}=${ua.count}")
                 }
             }
+        }
+
+        private fun List<SourceCount>.formatSourceCounts(): String {
+            if (isEmpty()) return ""
+            return joinToString(prefix = " (", postfix = ")") { "${it.source}=${it.count}" }
         }
 
         private fun StringBuilder.appendStatsSection(label: String, entries: List<String>) {

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceClientIdentityTracker.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceClientIdentityTracker.kt
@@ -6,6 +6,10 @@ import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
+internal const val AUTH_FAILURE_SOURCE_HTTP = "http"
+internal const val AUTH_FAILURE_SOURCE_WS = "ws"
+private const val AUTH_FAILURE_SOURCE_UNKNOWN = "<unknown>"
+
 /**
  * In-memory client-identity tracker used for the device-activity log.
  * Stores the last User-Agent and `seenAt` per device for successful auth, and a capped
@@ -23,6 +27,7 @@ class DeviceClientIdentityTracker @Inject constructor() {
         val seenAt: Instant,
         val reasonTag: String,
         val userAgent: String,
+        val source: String = AUTH_FAILURE_SOURCE_HTTP,
     )
 
     private val activity = ConcurrentHashMap<DeviceKey, TrackedActivity>()
@@ -50,11 +55,17 @@ class DeviceClientIdentityTracker @Inject constructor() {
 
     fun snapshotActivity(): Map<DeviceKey, TrackedActivity> = activity.toMap()
 
-    fun recordAuthFailure(reasonTag: String, rawUserAgent: String?, seenAt: Instant = Instant.now()) {
+    fun recordAuthFailure(
+        reasonTag: String,
+        rawUserAgent: String?,
+        seenAt: Instant = Instant.now(),
+        source: String = AUTH_FAILURE_SOURCE_HTTP,
+    ) {
         val event = AuthFailureEvent(
             seenAt = seenAt,
             reasonTag = reasonTag,
             userAgent = sanitizeUserAgent(rawUserAgent) ?: "",
+            source = sanitizeSource(source) ?: AUTH_FAILURE_SOURCE_UNKNOWN,
         )
         synchronized(authFailuresLock) {
             authFailures.addLast(event)
@@ -84,6 +95,14 @@ class DeviceClientIdentityTracker @Inject constructor() {
                 ?.trim()
                 ?.ifBlank { null }
                 ?.take(MAX_USER_AGENT_LENGTH)
+        }
+
+        private fun sanitizeSource(raw: String?): String? {
+            return raw
+                ?.replace(CONTROL_CHARS, " ")
+                ?.trim()
+                ?.ifBlank { null }
+                ?.take(32)
         }
 
         private fun normalizeOctiUserAgent(raw: String?): String? {

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceRepo.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceRepo.kt
@@ -200,6 +200,24 @@ class DeviceRepo @Inject constructor(
         return devices.values.any { it.id == deviceId }
     }
 
+    enum class MissingDeviceReason(val tag: String) {
+        UNKNOWN_ACCOUNT("unknown-account"),
+        DEVICE_ACCOUNT_MISMATCH("device-account-mismatch"),
+        UNKNOWN_DEVICE("unknown-device"),
+    }
+
+    suspend fun classifyMissingDevice(key: DeviceKey): MissingDeviceReason {
+        if (accountsRepo.getAccount(key.accountId) == null) {
+            return MissingDeviceReason.UNKNOWN_ACCOUNT
+        }
+
+        return if (devices.values.any { it.id == key.deviceId && it.accountId != key.accountId }) {
+            MissingDeviceReason.DEVICE_ACCOUNT_MISMATCH
+        } else {
+            MissingDeviceReason.UNKNOWN_DEVICE
+        }
+    }
+
     suspend fun getDevices(accountId: AccountId): Collection<Device> {
         val accountDevices = mutableSetOf<Device>()
         devices.forEach {

--- a/src/main/kotlin/eu/darken/octi/server/ws/WsRoute.kt
+++ b/src/main/kotlin/eu/darken/octi/server/ws/WsRoute.kt
@@ -13,6 +13,7 @@ import eu.darken.octi.server.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.server.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.server.common.debug.logging.log
 import eu.darken.octi.server.common.debug.logging.logTag
+import eu.darken.octi.server.device.AUTH_FAILURE_SOURCE_WS
 import eu.darken.octi.server.device.DeviceClientIdentityTracker
 import eu.darken.octi.server.device.DeviceRepo
 import io.ktor.server.request.*
@@ -48,7 +49,11 @@ class WsRoute @Inject constructor(
                 is AuthResult.Success -> authResult
                 is AuthResult.Failure -> {
                     log(TAG, WARN) { "WS auth failed: ${authResult.reason}" }
-                    deviceClientIdentityTracker.recordAuthFailure(authResult.tag, call.request.userAgent())
+                    deviceClientIdentityTracker.recordAuthFailure(
+                        reasonTag = authResult.tag,
+                        rawUserAgent = call.request.userAgent(),
+                        source = AUTH_FAILURE_SOURCE_WS,
+                    )
                     close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Authentication failed"))
                     return@webSocket
                 }

--- a/src/test/kotlin/eu/darken/octi/server/common/AuthenticateDeviceTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/common/AuthenticateDeviceTest.kt
@@ -3,6 +3,7 @@ package eu.darken.octi.server.common
 import eu.darken.octi.server.device.Device
 import eu.darken.octi.server.device.DeviceKey
 import eu.darken.octi.server.device.DeviceRepo
+import eu.darken.octi.server.device.DeviceRepo.MissingDeviceReason
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
@@ -163,7 +164,9 @@ class AuthenticateDeviceTest {
     @Test
     fun `unknown device returns NotFound`() = runTest {
         val unknownId = UUID.randomUUID()
-        coEvery { deviceRepo.getDevice(DeviceKey(accountId, unknownId)) } returns null
+        val unknownKey = DeviceKey(accountId, unknownId)
+        coEvery { deviceRepo.getDevice(unknownKey) } returns null
+        coEvery { deviceRepo.classifyMissingDevice(unknownKey) } returns MissingDeviceReason.UNKNOWN_DEVICE
 
         val result = authenticateDevice(
             deviceIdHeader = unknownId.toString(),
@@ -174,6 +177,42 @@ class AuthenticateDeviceTest {
         result.shouldBeInstanceOf<AuthResult.Failure>()
         result.status.value shouldBe 404
         result.tag shouldBe "unknown-device"
+    }
+
+    @Test
+    fun `unknown account returns NotFound with unknown-account tag`() = runTest {
+        val unknownAccount = UUID.randomUUID()
+        val unknownKey = DeviceKey(unknownAccount, deviceId)
+        coEvery { deviceRepo.getDevice(unknownKey) } returns null
+        coEvery { deviceRepo.classifyMissingDevice(unknownKey) } returns MissingDeviceReason.UNKNOWN_ACCOUNT
+
+        val result = authenticateDevice(
+            deviceIdHeader = deviceId.toString(),
+            authHeader = basicAuth(account = unknownAccount),
+            deviceRepo = deviceRepo,
+        )
+
+        result.shouldBeInstanceOf<AuthResult.Failure>()
+        result.status.value shouldBe 404
+        result.tag shouldBe "unknown-account"
+    }
+
+    @Test
+    fun `device account mismatch returns NotFound with mismatch tag`() = runTest {
+        val otherAccount = UUID.randomUUID()
+        val mismatchedKey = DeviceKey(otherAccount, deviceId)
+        coEvery { deviceRepo.getDevice(mismatchedKey) } returns null
+        coEvery { deviceRepo.classifyMissingDevice(mismatchedKey) } returns MissingDeviceReason.DEVICE_ACCOUNT_MISMATCH
+
+        val result = authenticateDevice(
+            deviceIdHeader = deviceId.toString(),
+            authHeader = basicAuth(account = otherAccount),
+            deviceRepo = deviceRepo,
+        )
+
+        result.shouldBeInstanceOf<AuthResult.Failure>()
+        result.status.value shouldBe 404
+        result.tag shouldBe "device-account-mismatch"
     }
 
     @Test

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceActivityReporterTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceActivityReporterTest.kt
@@ -186,7 +186,12 @@ class DeviceActivityReporterTest {
         val failures = listOf(
             AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "bad-credentials", "octi/1.0.0/FOSS"),
             AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "bad-credentials", "octi/1.0.0/FOSS"),
-            AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "bad-credentials", "ktor-client"),
+            AuthFailureEvent(
+                seenAt = now.minus(Duration.ofMinutes(5)),
+                reasonTag = "bad-credentials",
+                userAgent = "ktor-client",
+                source = AUTH_FAILURE_SOURCE_WS,
+            ),
             AuthFailureEvent(now.minus(Duration.ofMinutes(5)), "unknown-device", "octi/0.9.0/GPLAY"),
         )
 
@@ -200,6 +205,10 @@ class DeviceActivityReporterTest {
         report.oneHour.authFailures.byReason.map { it.reasonTag to it.count } shouldBe listOf(
             "bad-credentials" to 3,
             "unknown-device" to 1,
+        )
+        report.oneHour.authFailures.byReason[0].sources shouldBe listOf(
+            DeviceActivityReporter.SourceCount(AUTH_FAILURE_SOURCE_HTTP, 2),
+            DeviceActivityReporter.SourceCount(AUTH_FAILURE_SOURCE_WS, 1),
         )
         report.oneHour.authFailures.byReason[0].topUserAgents shouldBe listOf(
             DeviceActivityReporter.UserAgentCount("octi/1.0.0/FOSS", 2),
@@ -272,9 +281,9 @@ class DeviceActivityReporterTest {
                 versions:
                   1.0.0=1 (100.0%)
                 auth-failures: total=3
-                  bad-credentials=2
+                  bad-credentials=2 (http=2)
                     octi/1.0.0/FOSS=2
-                  missing-device-id=1
+                  missing-device-id=1 (http=1)
                     <unknown>=1
               24h: total=1
                 flavors:
@@ -282,9 +291,9 @@ class DeviceActivityReporterTest {
                 versions:
                   1.0.0=1 (100.0%)
                 auth-failures: total=3
-                  bad-credentials=2
+                  bad-credentials=2 (http=2)
                     octi/1.0.0/FOSS=2
-                  missing-device-id=1
+                  missing-device-id=1 (http=1)
                     <unknown>=1
             """.trimIndent()
     }

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceClientIdentityTrackerTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceClientIdentityTrackerTest.kt
@@ -93,7 +93,22 @@ class DeviceClientIdentityTrackerTest {
             seenAt = now,
             reasonTag = "bad-credentials",
             userAgent = "octi/1.0.0/FOSS",
+            source = AUTH_FAILURE_SOURCE_HTTP,
         )
+    }
+
+    @Test
+    fun `auth failure source is recorded`() {
+        val tracker = DeviceClientIdentityTracker()
+
+        tracker.recordAuthFailure(
+            reasonTag = "unknown-device",
+            rawUserAgent = "octi/1.0.0/FOSS",
+            seenAt = now,
+            source = AUTH_FAILURE_SOURCE_WS,
+        )
+
+        tracker.snapshotAuthFailures(now)[0].source shouldBe AUTH_FAILURE_SOURCE_WS
     }
 
     @Test

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceFlowTest.kt
@@ -314,6 +314,37 @@ class DeviceFlowTest : TestRunner() {
     }
 
     @Test
+    fun `auth failure with unknown account is tracked`() = runTest2 {
+        createDevice()
+
+        http.get(endPoint) {
+            addDeviceId(UUID.randomUUID())
+            addAuth(Auth(UUID.randomUUID().toString(), "missing-account-password"))
+        }.apply {
+            status shouldBe HttpStatusCode.NotFound
+        }
+
+        val failures = component.deviceClientIdentityTracker().snapshotAuthFailures()
+        failures.any { it.reasonTag == "unknown-account" } shouldBe true
+    }
+
+    @Test
+    fun `auth failure with device account mismatch is tracked`() = runTest2 {
+        val creds1 = createDevice()
+        val creds2 = createDevice()
+
+        http.get(endPoint) {
+            addDeviceId(creds1.deviceId)
+            addAuth(creds2.auth)
+        }.apply {
+            status shouldBe HttpStatusCode.NotFound
+        }
+
+        val failures = component.deviceClientIdentityTracker().snapshotAuthFailures()
+        failures.any { it.reasonTag == "device-account-mismatch" } shouldBe true
+    }
+
+    @Test
     fun `auth failure with bad password is tracked`() = runTest2 {
         val creds = createDevice()
 

--- a/src/test/kotlin/eu/darken/octi/server/ws/WsFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/ws/WsFlowTest.kt
@@ -3,6 +3,7 @@ package eu.darken.octi.server.ws
 import eu.darken.octi.*
 import eu.darken.octi.server.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.server.common.debug.logging.log
+import eu.darken.octi.server.device.AUTH_FAILURE_SOURCE_WS
 import eu.darken.octi.server.device.DeviceKey
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -158,6 +159,9 @@ class WsFlowTest : TestRunner() {
             if (reason?.code == CloseReason.Codes.VIOLATED_POLICY.code) closedWithPolicy = true
         }
         closedWithPolicy shouldBe true
+
+        val failures = component.deviceClientIdentityTracker().snapshotAuthFailures()
+        failures.any { it.reasonTag == "missing-device-id" && it.source == AUTH_FAILURE_SOURCE_WS } shouldBe true
         wsClient.close()
     }
 
@@ -191,7 +195,7 @@ class WsFlowTest : TestRunner() {
         wsClient.close()
 
         val failures = component.deviceClientIdentityTracker().snapshotAuthFailures()
-        failures.any { it.reasonTag == "missing-device-id" } shouldBe true
+        failures.any { it.reasonTag == "missing-device-id" && it.source == AUTH_FAILURE_SOURCE_WS } shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Record auth-failure source (`http` / `ws`) on each tracker event so the periodic `device-stats` log can split failures by entrypoint.
- Replace the single `unknown-device` tag with three reasons — `unknown-account`, `device-account-mismatch`, `unknown-device` — to distinguish brute-forcing the account-id space from cross-account device-id reuse from genuine lookup misses.
- Auth-failure section in the periodic report now renders `<reason>=<count> (http=N, ws=M)` per reason group.

## Test plan
- [ ] `./gradlew test --tests "eu.darken.octi.server.common.AuthenticateDeviceTest"`
- [ ] `./gradlew test --tests "eu.darken.octi.server.device.DeviceClientIdentityTrackerTest"`
- [ ] `./gradlew test --tests "eu.darken.octi.server.device.DeviceActivityReporterTest"`
- [ ] `./gradlew test --tests "eu.darken.octi.server.device.DeviceFlowTest"`
- [ ] `./gradlew test --tests "eu.darken.octi.server.ws.WsFlowTest"`
- [ ] `./gradlew check`