### PR TITLE
Add release and Docker image badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Octi Server
 
-[![Code tests & eval](https://img.shields.io/github/actions/workflow/status/d4rken-org/octi-server/code-checks.yml?logo=githubactions&label=Code%20tests)](https://github.com/d4rken-org/octi-server/actions)
+[![Code tests & eval](https://img.shields.io/github/actions/workflow/status/d4rken-org/octi-server/code-checks.yml?logo=githubactions&label=Code%20tests)](https://github.com/d4rken-org/octi-server/actions/workflows/code-checks.yml)
+[![Gradle wrapper](https://img.shields.io/github/actions/workflow/status/d4rken-org/octi-server/gradle-wrapper-validation.yml?logo=gradle&label=Gradle%20wrapper)](https://github.com/d4rken-org/octi-server/actions/workflows/gradle-wrapper-validation.yml)
+
+[![GitHub release](https://img.shields.io/github/v/release/d4rken-org/octi-server?logo=github&label=Release)](https://github.com/d4rken-org/octi-server/releases/latest)
+[![Docker image version](https://ghcr-badge.egpl.dev/d4rken-org/octi-server/latest_tag?trim=major&label=ghcr.io)](https://github.com/d4rken-org/octi-server/pkgs/container/octi-server)
+[![Docker image size](https://ghcr-badge.egpl.dev/d4rken-org/octi-server/size?color=%2344cc11&tag=latest&label=image%20size)](https://github.com/d4rken-org/octi-server/pkgs/container/octi-server)
 
 This is a synchronization server for [Octi](https://github.com/d4rken-org/octi)
 


### PR DESCRIPTION
## Summary
- Adds Gradle wrapper validation workflow status badge
- Adds latest GitHub release version badge
- Adds ghcr.io Docker image version + size badges (via `ghcr-badge.egpl.dev` shim, since ghcr.io does not expose these natively)
- Fixes the existing CI badge link to point at the specific workflow file instead of the generic `/actions` page

## Test plan
- [ ] Confirm all five badges render on the rendered README at github.com after merge
- [ ] Confirm badge links resolve (workflow runs, release page, ghcr.io package page)
