### PR TITLE
Add CORS plugin with allowlist for browser-based clients

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-server-body-limit:$ktorVersion")
+    implementation("io.ktor:ktor-server-cors:$ktorVersion")
     implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
     implementation("io.ktor:ktor-server-websockets:$ktorVersion")
     implementation("io.ktor:ktor-server-partial-content:$ktorVersion")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,7 @@
 # - OCTI_DEBUG: Enable debug mode (default: false)
 # - OCTI_DATA_DIR: Override data directory path (default: auto-detect)
 # - OCTI_TRUSTED_PROXY_IPS: Comma-separated trusted proxy IPs (default: loopback)
+# - OCTI_CORS_ALLOWED_ORIGINS: Comma-separated origins (scheme://host[:port]) for browser clients (default: none)
 #
 # Default data path: /etc/octi-server
 # Deprecated path: /etc/octi-sync-server (still supported via auto-detection)
@@ -77,6 +78,7 @@ add_optional_arg OCTI_RATE_LIMIT "--rate-limit"
 add_optional_arg OCTI_RATE_LIMIT_WINDOW_SECONDS "--rate-limit-window-seconds"
 add_optional_arg OCTI_PAYLOAD_LIMIT_KB "--payload-limit-kb"
 add_optional_arg OCTI_TRUSTED_PROXY_IPS "--trusted-proxy-ips"
+add_optional_arg OCTI_CORS_ALLOWED_ORIGINS "--cors-allowed-origins"
 
 if [ "${OCTI_DISABLE_RATE_LIMITS:-false}" = "true" ]; then
     CMD_ARGS+=("--disable-rate-limits")

--- a/src/main/kotlin/eu/darken/octi/server/App.kt
+++ b/src/main/kotlin/eu/darken/octi/server/App.kt
@@ -78,6 +78,16 @@ class App @Inject constructor(
         val accountRateLimit: Int = 256,
         val accountRateLimitWindowSeconds: Long = 60,
         val trustedProxyIps: Set<String> = IpHelper.DEFAULT_TRUSTED_PROXY_IPS,
+        // Origins (scheme://host[:port]) allowed by the CORS plugin for browser clients.
+        // Ships with the official octi-web hosting origins so the OOB UX works without
+        // operator config. Pass `--cors-allowed-origins=` (empty) to disable browser
+        // access entirely. Non-browser clients (Android, desktop, CLI) are unaffected
+        // by this setting regardless.
+        val corsAllowedOrigins: Set<String> = setOf(
+            "https://web.octi.darken.eu",
+            "https://d4rken.github.io",
+            "https://d4rken-org.github.io",
+        ),
     )
 
     companion object {
@@ -145,6 +155,7 @@ class App @Inject constructor(
                 accountRateLimitWindowSeconds = parseLongFlag(args, "--account-rate-limit-window-seconds", min = 1)
                     ?: defaults.accountRateLimitWindowSeconds,
                 trustedProxyIps = parseTrustedProxyIps(args) ?: defaults.trustedProxyIps,
+                corsAllowedOrigins = parseCorsAllowedOrigins(args) ?: defaults.corsAllowedOrigins,
             )
         }
 
@@ -196,6 +207,29 @@ class App @Inject constructor(
                 .map {
                     IpHelper.parseIpOrNull(it)
                         ?: throw IllegalArgumentException("Invalid value for --trusted-proxy-ips: '$it'")
+                }
+                .toSet()
+        }
+
+        // Origins must look like "scheme://host" or "scheme://host:port" — we validate
+        // shape strictly so a typo (e.g. trailing slash, missing scheme, "*") fails the
+        // boot rather than silently producing an unreachable allowlist.
+        private val ORIGIN_REGEX = Regex("""^https?://[^/\s]+$""")
+
+        internal fun parseCorsAllowedOrigins(args: Array<String>): Set<String>? {
+            val matches = args.filter { it.startsWith("--cors-allowed-origins=") }
+            if (matches.isEmpty()) return null
+            require(matches.size == 1) { "--cors-allowed-origins specified more than once: ${matches.joinToString(" ")}" }
+            return matches.single()
+                .substringAfter('=')
+                .split(',')
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .map {
+                    require(ORIGIN_REGEX.matches(it)) {
+                        "Invalid value for --cors-allowed-origins: '$it' (expected scheme://host[:port], no trailing slash)"
+                    }
+                    it
                 }
                 .toSet()
         }

--- a/src/main/kotlin/eu/darken/octi/server/Server.kt
+++ b/src/main/kotlin/eu/darken/octi/server/Server.kt
@@ -33,6 +33,7 @@ import io.ktor.server.netty.*
 import io.ktor.server.plugins.autohead.*
 // ConditionalHeaders not used globally — see comment in server setup
 import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.plugins.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
@@ -65,6 +66,55 @@ class Server @Inject constructor(
     private val server by lazy {
         embeddedServer(Netty, config.port) {
             installCallLogging(config.trustedProxyIps)
+            // CORS is installed before rate-limit/auth so preflight OPTIONS short-circuit
+            // here and never reach those paths. Browser clients are the only callers
+            // subject to CORS; Android/desktop/CLI are unaffected regardless of config.
+            if (config.corsAllowedOrigins.isNotEmpty()) {
+                log(TAG, INFO) { "CORS allowed origins: ${config.corsAllowedOrigins.joinToString(", ")}" }
+                install(CORS) {
+                    config.corsAllowedOrigins.forEach { origin ->
+                        // hosts() expects host[:port] split from scheme; allowHost handles parsing.
+                        // Format already validated by App.parseCorsAllowedOrigins.
+                        val scheme = origin.substringBefore("://")
+                        val hostAndPort = origin.substringAfter("://")
+                        allowHost(hostAndPort, schemes = listOf(scheme))
+                    }
+                    allowMethod(HttpMethod.Get)
+                    allowMethod(HttpMethod.Post)
+                    allowMethod(HttpMethod.Put)
+                    allowMethod(HttpMethod.Patch)
+                    allowMethod(HttpMethod.Delete)
+                    allowMethod(HttpMethod.Head)
+                    allowMethod(HttpMethod.Options)
+                    allowHeader(HttpHeaders.Authorization)
+                    allowHeader(HttpHeaders.ContentType)
+                    allowHeader(HttpHeaders.IfMatch)
+                    allowHeader(HttpHeaders.IfNoneMatch)
+                    allowHeader(HttpHeaders.Range)
+                    allowHeader(HttpHeaders.IfRange)
+                    allowHeader("X-Device-ID")
+                    allowHeader("Octi-Device-Version")
+                    allowHeader("Octi-Device-Platform")
+                    allowHeader("Octi-Device-Label")
+                    allowHeader("Upload-Offset")
+                    exposeHeader(HttpHeaders.ETag)
+                    exposeHeader(HttpHeaders.LastModified)
+                    exposeHeader(HttpHeaders.ContentRange)
+                    exposeHeader(HttpHeaders.AcceptRanges)
+                    exposeHeader(HttpHeaders.RetryAfter)
+                    exposeHeader("Upload-Offset")
+                    exposeHeader("Upload-Length")
+                    exposeHeader("Upload-Expires")
+                    exposeHeader("Upload-State")
+                    exposeHeader("X-Blob-ID")
+                    // We use Authorization headers, not cookies — keep credentials off so
+                    // browsers don't refuse the response when the same origin is reused
+                    // across users on the SPA.
+                    allowCredentials = false
+                }
+            } else {
+                log(TAG, INFO) { "CORS disabled (--cors-allowed-origins= was set to empty); browser clients won't be able to reach this server" }
+            }
             install(AutoHeadResponse)
             // PartialContent is NOT installed globally — BlobRoute.downloadBlob handles
             // Range / If-Range / Last-Modified manually because BlobHandle wraps an

--- a/src/main/kotlin/eu/darken/octi/server/common/RateLimiter.kt
+++ b/src/main/kotlin/eu/darken/octi/server/common/RateLimiter.kt
@@ -69,6 +69,11 @@ fun Application.installRateLimit(
     }
 
     intercept(ApplicationCallPipeline.Plugins) {
+        // CORS preflight is a browser-internal protocol detail, not a meaningful client
+        // action. Counting it against the per-IP budget would let a chatty preflight
+        // pattern starve real traffic.
+        if (call.request.httpMethod == HttpMethod.Options) return@intercept
+
         val clientIp = call.request.clientIp(trustedProxyIps)
         val now = Instant.now()
         val calldetails = "${call.request.httpMethod.value} ${call.request.uri}"

--- a/src/test/kotlin/eu/darken/octi/server/AppCliParsingTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/AppCliParsingTest.kt
@@ -76,4 +76,68 @@ class AppCliParsingTest {
         // AccountRateLimiter.acquire treats <= 0 as disabled, so the default must be > 0.
         (cfg.accountRateLimit > 0) shouldBe true
     }
+
+    @Test
+    fun `--cors-allowed-origins defaults to the official octi-web hosting origins`() {
+        // OOB UX: a fresh self-hosted server can serve the official SPA without any flag.
+        // Self-hosters who want a tighter allowlist override via the flag (incl. empty).
+        val origins = App.parseConfig(baseArgs).corsAllowedOrigins
+        origins shouldBe setOf(
+            "https://web.octi.darken.eu",
+            "https://d4rken.github.io",
+            "https://d4rken-org.github.io",
+        )
+    }
+
+    @Test
+    fun `--cors-allowed-origins= (empty) disables browser access`() {
+        // Explicit empty value overrides the baked-in defaults. The split-and-filter
+        // pipeline naturally yields an empty set rather than crashing on empty input.
+        App.parseConfig(baseArgs + "--cors-allowed-origins=").corsAllowedOrigins shouldBe emptySet()
+    }
+
+    @Test
+    fun `--cors-allowed-origins parses a single origin`() {
+        val cfg = App.parseConfig(baseArgs + "--cors-allowed-origins=https://web.octi.darken.eu")
+        cfg.corsAllowedOrigins shouldBe setOf("https://web.octi.darken.eu")
+    }
+
+    @Test
+    fun `--cors-allowed-origins parses comma-separated origins with whitespace`() {
+        val cfg = App.parseConfig(baseArgs + "--cors-allowed-origins=https://web.octi.darken.eu, http://localhost:5173")
+        cfg.corsAllowedOrigins shouldBe setOf("https://web.octi.darken.eu", "http://localhost:5173")
+    }
+
+    @Test
+    fun `--cors-allowed-origins rejects bare host without scheme`() {
+        val ex = shouldThrow<IllegalArgumentException> {
+            App.parseConfig(baseArgs + "--cors-allowed-origins=web.octi.darken.eu")
+        }
+        ex.message!! shouldContain "--cors-allowed-origins"
+    }
+
+    @Test
+    fun `--cors-allowed-origins rejects trailing slash`() {
+        shouldThrow<IllegalArgumentException> {
+            App.parseConfig(baseArgs + "--cors-allowed-origins=https://web.octi.darken.eu/")
+        }
+    }
+
+    @Test
+    fun `--cors-allowed-origins rejects wildcard`() {
+        shouldThrow<IllegalArgumentException> {
+            App.parseConfig(baseArgs + "--cors-allowed-origins=*")
+        }
+    }
+
+    @Test
+    fun `--cors-allowed-origins rejects duplicate flags`() {
+        shouldThrow<IllegalArgumentException> {
+            App.parseConfig(
+                baseArgs +
+                    "--cors-allowed-origins=https://a.example" +
+                    "--cors-allowed-origins=https://b.example"
+            )
+        }
+    }
 }

--- a/src/test/kotlin/eu/darken/octi/server/common/CorsFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/common/CorsFlowTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.server.common
 
 import eu.darken.octi.TestRunner
+import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -101,6 +102,36 @@ class CorsFlowTest : TestRunner() {
         }.apply {
             status shouldBe HttpStatusCode.Forbidden
             headers[HttpHeaders.AccessControlAllowOrigin] shouldBe null
+        }
+    }
+
+    @Test
+    fun `actual response exposes blob and upload headers to the browser`() = runTest2(appConfig = corsConfig) {
+        // Without Access-Control-Expose-Headers, fetch() in the SPA can't read these even
+        // though the server sends them — so we verify the configured exposeHeader set actually
+        // lands on a real (non-preflight) response.
+        http.get("/v1/status") {
+            header(HttpHeaders.Origin, allowedOrigin)
+        }.apply {
+            status shouldBe HttpStatusCode.OK
+            val exposed = headers[HttpHeaders.AccessControlExposeHeaders]?.lowercase() ?: ""
+            // Last-Modified is a CORS-safelisted response header — browsers expose it by default
+            // so Ktor's plugin (correctly) omits it from Access-Control-Expose-Headers even
+            // when we configure it. Not asserted here for that reason.
+            val expected = listOf(
+                "etag",
+                "content-range",
+                "accept-ranges",
+                "retry-after",
+                "upload-offset",
+                "upload-length",
+                "upload-expires",
+                "upload-state",
+                "x-blob-id",
+            )
+            withClue("Access-Control-Expose-Headers='$exposed' missing: ${expected.filterNot { it in exposed }}") {
+                expected.forEach { (it in exposed) shouldBe true }
+            }
         }
     }
 

--- a/src/test/kotlin/eu/darken/octi/server/common/CorsFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/common/CorsFlowTest.kt
@@ -1,0 +1,121 @@
+package eu.darken.octi.server.common
+
+import eu.darken.octi.TestRunner
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.*
+import io.ktor.http.*
+import org.junit.jupiter.api.Test
+
+class CorsFlowTest : TestRunner() {
+
+    private val allowedOrigin = "http://localhost:5173"
+    private val disallowedOrigin = "http://evil.example"
+
+    private val corsConfig = baseConfig.copy(corsAllowedOrigins = setOf(allowedOrigin))
+    private val corsDisabledConfig = baseConfig.copy(corsAllowedOrigins = emptySet())
+
+    @Test
+    fun `when explicitly disabled - no CORS headers emitted`() = runTest2(appConfig = corsDisabledConfig) {
+        http.get("/v1/status") {
+            header(HttpHeaders.Origin, allowedOrigin)
+        }.apply {
+            status shouldBe HttpStatusCode.OK
+            headers[HttpHeaders.AccessControlAllowOrigin] shouldBe null
+        }
+    }
+
+    @Test
+    fun `when explicitly disabled - preflight has no Allow-Origin`() = runTest2(appConfig = corsDisabledConfig) {
+        // Without the CORS plugin installed, Ktor doesn't synthesize a preflight response.
+        // The actual status code is uninteresting (some routes 404 OPTIONS, some 405); what
+        // matters is that no Allow-Origin header is emitted — which is what blocks the browser.
+        val response = http.options("/v1/devices") {
+            header(HttpHeaders.Origin, allowedOrigin)
+            header(HttpHeaders.AccessControlRequestMethod, HttpMethod.Get.value)
+            header(HttpHeaders.AccessControlRequestHeaders, HttpHeaders.Authorization)
+        }
+        response.headers[HttpHeaders.AccessControlAllowOrigin] shouldBe null
+    }
+
+    @Test
+    fun `default config allows the official octi-web origin out of the box`() = runTest2 {
+        // baseConfig inherits Config defaults, which include https://web.octi.darken.eu —
+        // this guards the OOB UX promise: docker run + no flags = SPA works.
+        http.get("/v1/status") {
+            header(HttpHeaders.Origin, "https://web.octi.darken.eu")
+        }.apply {
+            status shouldBe HttpStatusCode.OK
+            headers[HttpHeaders.AccessControlAllowOrigin] shouldBe "https://web.octi.darken.eu"
+        }
+    }
+
+    @Test
+    fun `default config allows the d4rken github pages origin`() = runTest2 {
+        http.get("/v1/status") {
+            header(HttpHeaders.Origin, "https://d4rken.github.io")
+        }.apply {
+            status shouldBe HttpStatusCode.OK
+            headers[HttpHeaders.AccessControlAllowOrigin] shouldBe "https://d4rken.github.io"
+        }
+    }
+
+    @Test
+    fun `preflight from allowed origin returns CORS headers`() = runTest2(appConfig = corsConfig) {
+        val response = http.options("/v1/devices") {
+            header(HttpHeaders.Origin, allowedOrigin)
+            header(HttpHeaders.AccessControlRequestMethod, HttpMethod.Get.value)
+            header(HttpHeaders.AccessControlRequestHeaders, "${HttpHeaders.Authorization},X-Device-ID")
+        }
+        // Ktor's CORS plugin responds 200 OK with allow-origin echoed
+        response.status shouldBe HttpStatusCode.OK
+        response.headers[HttpHeaders.AccessControlAllowOrigin] shouldBe allowedOrigin
+    }
+
+    @Test
+    fun `preflight from disallowed origin gets no Allow-Origin`() = runTest2(appConfig = corsConfig) {
+        val response = http.options("/v1/devices") {
+            header(HttpHeaders.Origin, disallowedOrigin)
+            header(HttpHeaders.AccessControlRequestMethod, HttpMethod.Get.value)
+        }
+        // Browser refuses the request because the header is missing — server itself doesn't reject loudly
+        response.headers[HttpHeaders.AccessControlAllowOrigin] shouldBe null
+    }
+
+    @Test
+    fun `actual GET from allowed origin includes Allow-Origin header`() = runTest2(appConfig = corsConfig) {
+        http.get("/v1/status") {
+            header(HttpHeaders.Origin, allowedOrigin)
+        }.apply {
+            status shouldBe HttpStatusCode.OK
+            headers[HttpHeaders.AccessControlAllowOrigin] shouldBe allowedOrigin
+        }
+    }
+
+    @Test
+    fun `actual GET from disallowed origin is rejected with 403`() = runTest2(appConfig = corsConfig) {
+        // Ktor's CORS plugin rejects unlisted origins server-side (not just by withholding the
+        // Allow-Origin header). Browsers would refuse the response anyway, but failing fast
+        // also avoids leaking server state to a curl from a disallowed origin.
+        http.get("/v1/status") {
+            header(HttpHeaders.Origin, disallowedOrigin)
+        }.apply {
+            status shouldBe HttpStatusCode.Forbidden
+            headers[HttpHeaders.AccessControlAllowOrigin] shouldBe null
+        }
+    }
+
+    @Test
+    fun `preflight exposes the auth and device headers we need`() = runTest2(appConfig = corsConfig) {
+        val response = http.options("/v1/account") {
+            header(HttpHeaders.Origin, allowedOrigin)
+            header(HttpHeaders.AccessControlRequestMethod, HttpMethod.Post.value)
+            header(HttpHeaders.AccessControlRequestHeaders, "${HttpHeaders.Authorization},X-Device-ID,Octi-Device-Platform,Octi-Device-Label")
+        }
+        response.status shouldBe HttpStatusCode.OK
+        val allowed = response.headers[HttpHeaders.AccessControlAllowHeaders]?.lowercase() ?: ""
+        // Ktor folds requested headers into the response — assert each one we plan to send
+        listOf("authorization", "x-device-id", "octi-device-platform", "octi-device-label").forEach {
+            (it in allowed) shouldBe true
+        }
+    }
+}

--- a/src/test/kotlin/eu/darken/octi/server/common/RateLimiterTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/common/RateLimiterTest.kt
@@ -95,6 +95,38 @@ class RateLimiterTest : TestRunner() {
     }
 
     @Test
+    fun `OPTIONS preflight does not consume rate limit budget`() = runTest2(
+        appConfig = baseConfig.copy(
+            rateLimit = RateLimitConfig(limit = 2, resetTime = Duration.ofSeconds(5)),
+            // CORS only added so OPTIONS gets a clean preflight response instead of 405;
+            // the bypass itself runs in the rate-limit interceptor before CORS sees the call.
+            corsAllowedOrigins = setOf("http://localhost:5173"),
+        )
+    ) {
+        // Hammer with preflights well past the limit — none of these should tick the counter.
+        repeat(10) {
+            http.options("/v1/devices") {
+                header(HttpHeaders.Origin, "http://localhost:5173")
+                header(HttpHeaders.AccessControlRequestMethod, HttpMethod.Get.value)
+            }
+            Thread.sleep(20)
+        }
+
+        // Both real GETs still pass — proves the budget is intact.
+        repeat(2) {
+            http.get("/v1/status").apply {
+                status shouldBe HttpStatusCode.OK
+            }
+            Thread.sleep(100)
+        }
+
+        // And the 3rd GET is rate-limited as normal.
+        http.get("/v1/status").apply {
+            status shouldBe HttpStatusCode.TooManyRequests
+        }
+    }
+
+    @Test
     fun `test stale rate limit entries are cleaned up`() = runTest2(
         appConfig = baseConfig.copy(
             rateLimit = RateLimitConfig(limit = 2, resetTime = Duration.ofSeconds(2))


### PR DESCRIPTION
Adds the Ktor CORS plugin needed by the new in-browser octi-web client. Browser SPAs can't reach the sync-server without server-side CORS headers (browser-enforced), so this is a hard prerequisite for the web client.

## What
- New `--cors-allowed-origins` flag (CLI + `OCTI_CORS_ALLOWED_ORIGINS` env via docker entrypoint)
- Allowlist defaults to the official octi-web hosting origins: `https://web.octi.darken.eu`, `https://d4rken.github.io`, `https://d4rken-org.github.io`. Override or set to empty to lock down.
- `OPTIONS` preflights skip the per-IP rate limit so chatty preflights can't starve real traffic.
- Origin format validated at startup (`scheme://host[:port]`, no trailing slash, no wildcards).
- Active origins logged at boot.

## Tests
- `AppCliParsingTest` — 8 cases for the new flag (defaults, parsing, validation, empty-disables, duplicates rejected).
- `CorsFlowTest` — 7 integration cases hitting the running server: allowed-origin preflight + actual GET, disallowed-origin rejection (403), explicit-disabled mode, header allowlist coverage, OOB defaults.

## Test plan
- [x] `./gradlew test --tests AppCliParsingTest --tests CorsFlowTest`
- [x] `./gradlew assemble`
- [ ] Manual: `./bin/octi-server --datapath=/tmp/foo --cors-allowed-origins=http://localhost:5173` then curl from a browser tab