### PR TITLE
Accept and echo Octi-Device-Capabilities header

### DIFF
--- a/src/main/kotlin/eu/darken/octi/server/Server.kt
+++ b/src/main/kotlin/eu/darken/octi/server/Server.kt
@@ -96,6 +96,7 @@ class Server @Inject constructor(
                     allowHeader("Octi-Device-Version")
                     allowHeader("Octi-Device-Platform")
                     allowHeader("Octi-Device-Label")
+                    allowHeader("Octi-Device-Capabilities")
                     allowHeader("Upload-Offset")
                     exposeHeader(HttpHeaders.ETag)
                     exposeHeader(HttpHeaders.LastModified)

--- a/src/main/kotlin/eu/darken/octi/server/account/AccountRoute.kt
+++ b/src/main/kotlin/eu/darken/octi/server/account/AccountRoute.kt
@@ -10,6 +10,7 @@ import eu.darken.octi.server.common.debug.logging.logTag
 import eu.darken.octi.server.common.debug.logging.shortId
 import eu.darken.octi.server.common.headerDeviceId
 import eu.darken.octi.server.common.normalizeLabel
+import eu.darken.octi.server.common.parseCapabilitiesHeader
 import eu.darken.octi.server.common.verifyCaller
 import eu.darken.octi.server.device.DeviceClientIdentityTracker
 import eu.darken.octi.server.device.DeviceLimitExceededException
@@ -96,6 +97,7 @@ class AccountRoute @Inject constructor(
                 version = call.request.headers["Octi-Device-Version"] ?: call.request.headers["User-Agent"],
                 platform = call.request.headers["Octi-Device-Platform"],
                 label = normalizeLabel(call.request.headers["Octi-Device-Label"]),
+                capabilities = parseCapabilitiesHeader(call.request.headers["Octi-Device-Capabilities"]),
             )
         } catch (e: DeviceLimitExceededException) {
             if (share != null) {

--- a/src/main/kotlin/eu/darken/octi/server/common/HttpExtensions.kt
+++ b/src/main/kotlin/eu/darken/octi/server/common/HttpExtensions.kt
@@ -15,6 +15,10 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
 import java.time.Instant
 import java.util.*
 
@@ -45,9 +49,61 @@ data class DeviceMetadataPatch(
     val version: String? = null,
     val platform: String? = null,
     val label: String? = null,
+    val capabilities: Set<String>? = null,
 )
 
 fun normalizeLabel(raw: String?): String? = raw?.trim()?.take(128)?.ifBlank { null }
+
+private val capabilityParseJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * Parses the `Octi-Device-Capabilities` HTTP header value into a validated [Set] of tag
+ * strings. Mirrors the validation in the client-side `CapabilitiesCodec`: max [MAX_CAPABILITY_TAGS]
+ * tags, max [MAX_CAPABILITY_TAG_LENGTH] chars each, ASCII `<namespace>:<value>` shape.
+ *
+ * Returns `null` if the header is absent, blank, malformed, or violates a limit — the device
+ * is treated as not reporting capabilities. Drops the whole set on any bad tag (no partial
+ * acceptance) so peers see a consistent "either valid or absent" wire contract.
+ */
+fun parseCapabilitiesHeader(raw: String?): Set<String>? {
+    if (raw.isNullOrBlank()) return null
+    if (raw.length > MAX_CAPABILITY_HEADER_LENGTH) {
+        log(TAG, WARN) { "parseCapabilitiesHeader: header too long (${raw.length})" }
+        return null
+    }
+    val element = try {
+        capabilityParseJson.parseToJsonElement(raw)
+    } catch (e: SerializationException) {
+        log(TAG, WARN) { "parseCapabilitiesHeader: malformed JSON: ${e.message}" }
+        return null
+    }
+    val array = element as? JsonArray ?: run {
+        log(TAG, WARN) { "parseCapabilitiesHeader: not a JSON array" }
+        return null
+    }
+    if (array.size > MAX_CAPABILITY_TAGS) {
+        log(TAG, WARN) { "parseCapabilitiesHeader: too many tags (${array.size})" }
+        return null
+    }
+    val result = LinkedHashSet<String>(array.size.coerceAtLeast(1))
+    for (item in array) {
+        val str = (item as? JsonPrimitive)?.takeIf { it.isString }?.content ?: run {
+            log(TAG, WARN) { "parseCapabilitiesHeader: non-string element" }
+            return null
+        }
+        if (str.length > MAX_CAPABILITY_TAG_LENGTH || !CAPABILITY_TAG_REGEX.matches(str)) {
+            log(TAG, WARN) { "parseCapabilitiesHeader: invalid tag shape '$str'" }
+            return null
+        }
+        result.add(str)
+    }
+    return result
+}
+
+const val MAX_CAPABILITY_TAGS = 64
+const val MAX_CAPABILITY_TAG_LENGTH = 128
+const val MAX_CAPABILITY_HEADER_LENGTH = 4096
+val CAPABILITY_TAG_REGEX = Regex("""[a-z][a-z0-9]*:[A-Za-z0-9._\-]+""")
 
 /**
  * Validates the auth headers and returns the device on success — no side effects.
@@ -110,6 +166,7 @@ suspend fun touchAuthenticatedDevice(
         metadata?.version?.let { v -> updated = updated.copy(version = v) }
         metadata?.platform?.let { p -> updated = updated.copy(platform = p) }
         metadata?.label?.let { l -> updated = updated.copy(label = l) }
+        metadata?.capabilities?.let { c -> updated = updated.copy(capabilities = c) }
         updated
     }
     if (clientIp != null && ipTracker != null) {
@@ -191,6 +248,7 @@ suspend fun RoutingContext.verifyCaller(tag: String, deviceRepo: DeviceRepo): De
             version = call.request.header("Octi-Device-Version"),
             platform = call.request.header("Octi-Device-Platform"),
             label = normalizeLabel(call.request.header("Octi-Device-Label")),
+            capabilities = parseCapabilitiesHeader(call.request.header("Octi-Device-Capabilities")),
         ),
     )
 }

--- a/src/main/kotlin/eu/darken/octi/server/device/Device.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/Device.kt
@@ -43,6 +43,9 @@ data class Device(
     val label: String?
         get() = data.label
 
+    val capabilities: Set<String>?
+        get() = data.capabilities
+
     val addedAt: Instant
         get() = data.addedAt
 
@@ -56,6 +59,13 @@ data class Device(
         val version: String? = null,
         val platform: String? = null,
         val label: String? = null,
+        /**
+         * Feature capability tags published by the device, format `<namespace>:<value>`
+         * (e.g. `encryption:AES256_GCM_SIV`). Opaque to the server — stored and echoed
+         * as-is. `null` = device hasn't reported capabilities; an empty set = device
+         * explicitly reports no capabilities. See [eu.darken.octi.server.common.parseCapabilitiesHeader].
+         */
+        val capabilities: Set<String>? = null,
         @Contextual val addedAt: Instant = Instant.now(),
         @Contextual val lastSeen: Instant = Instant.now(),
     ) {

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceRepo.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceRepo.kt
@@ -141,12 +141,14 @@ class DeviceRepo @Inject constructor(
         version: String?,
         platform: String? = null,
         label: String? = null,
+        capabilities: Set<String>? = null,
     ): Device {
         val data = Device.Data(
             id = deviceId,
             version = version,
             platform = platform,
             label = label,
+            capabilities = capabilities,
         )
         val device = Device(
             data = data,

--- a/src/main/kotlin/eu/darken/octi/server/device/DeviceRoute.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DeviceRoute.kt
@@ -74,6 +74,7 @@ class DeviceRoute @Inject constructor(
                     version = it.version,
                     platform = it.platform,
                     label = it.label,
+                    capabilities = it.capabilities,
                     addedAt = it.addedAt,
                     lastSeen = it.lastSeen,
                 )

--- a/src/main/kotlin/eu/darken/octi/server/device/DevicesResponse.kt
+++ b/src/main/kotlin/eu/darken/octi/server/device/DevicesResponse.kt
@@ -15,6 +15,7 @@ data class DevicesResponse(
         @SerialName("version") val version: String?,
         @SerialName("platform") val platform: String?,
         @SerialName("label") val label: String?,
+        @SerialName("capabilities") val capabilities: Set<String>? = null,
         @Contextual @SerialName("addedAt") val addedAt: Instant,
         @Contextual @SerialName("lastSeen") val lastSeen: Instant,
     )

--- a/src/main/kotlin/eu/darken/octi/server/ws/WsRoute.kt
+++ b/src/main/kotlin/eu/darken/octi/server/ws/WsRoute.kt
@@ -8,6 +8,7 @@ import eu.darken.octi.server.common.IpDeviceTracker
 import eu.darken.octi.server.common.authenticateDevice
 import eu.darken.octi.server.common.clientIp
 import eu.darken.octi.server.common.normalizeLabel
+import eu.darken.octi.server.common.parseCapabilitiesHeader
 import eu.darken.octi.server.common.touchAuthenticatedDevice
 import eu.darken.octi.server.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.server.common.debug.logging.Logging.Priority.WARN
@@ -80,6 +81,7 @@ class WsRoute @Inject constructor(
                     version = call.request.headers["Octi-Device-Version"],
                     platform = call.request.headers["Octi-Device-Platform"],
                     label = normalizeLabel(call.request.headers["Octi-Device-Label"]),
+                    capabilities = parseCapabilitiesHeader(call.request.headers["Octi-Device-Capabilities"]),
                 ),
             )
 

--- a/src/test/kotlin/eu/darken/octi/TestRunnerExtensions.kt
+++ b/src/test/kotlin/eu/darken/octi/TestRunnerExtensions.kt
@@ -59,6 +59,7 @@ suspend fun TestEnvironment.createDeviceRaw(
     version: String? = null,
     platform: String? = null,
     label: String? = null,
+    capabilities: String? = null,
     userAgent: String? = null,
 ): HttpResponse = this.http.run {
     post {
@@ -70,6 +71,7 @@ suspend fun TestEnvironment.createDeviceRaw(
         if (version != null) headers.append("Octi-Device-Version", version)
         if (platform != null) headers.append("Octi-Device-Platform", platform)
         if (label != null) headers.append("Octi-Device-Label", label)
+        if (capabilities != null) headers.append("Octi-Device-Capabilities", capabilities)
         if (userAgent != null) headers.set(HttpHeaders.UserAgent, userAgent)
     }
 }
@@ -80,9 +82,10 @@ suspend fun TestEnvironment.createDevice(
     version: String? = null,
     platform: String? = null,
     label: String? = null,
+    capabilities: String? = null,
     userAgent: String? = null,
 ): Credentials {
-    val credentials = createDeviceRaw(deviceId, shareCode, version, platform, label, userAgent).asAuth()
+    val credentials = createDeviceRaw(deviceId, shareCode, version, platform, label, capabilities, userAgent).asAuth()
     return Credentials(deviceId, credentials)
 }
 
@@ -115,6 +118,7 @@ data class TestDevices(
         val version: String? = "ktor-client",
         val platform: String? = null,
         val label: String? = null,
+        val capabilities: Set<String>? = null,
         val addedAt: String? = null,
         val lastSeen: String? = null,
     )

--- a/src/test/kotlin/eu/darken/octi/server/common/CorsFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/common/CorsFlowTest.kt
@@ -140,12 +140,21 @@ class CorsFlowTest : TestRunner() {
         val response = http.options("/v1/account") {
             header(HttpHeaders.Origin, allowedOrigin)
             header(HttpHeaders.AccessControlRequestMethod, HttpMethod.Post.value)
-            header(HttpHeaders.AccessControlRequestHeaders, "${HttpHeaders.Authorization},X-Device-ID,Octi-Device-Platform,Octi-Device-Label")
+            header(
+                HttpHeaders.AccessControlRequestHeaders,
+                "${HttpHeaders.Authorization},X-Device-ID,Octi-Device-Platform,Octi-Device-Label,Octi-Device-Capabilities",
+            )
         }
         response.status shouldBe HttpStatusCode.OK
         val allowed = response.headers[HttpHeaders.AccessControlAllowHeaders]?.lowercase() ?: ""
         // Ktor folds requested headers into the response — assert each one we plan to send
-        listOf("authorization", "x-device-id", "octi-device-platform", "octi-device-label").forEach {
+        listOf(
+            "authorization",
+            "x-device-id",
+            "octi-device-platform",
+            "octi-device-label",
+            "octi-device-capabilities",
+        ).forEach {
             (it in allowed) shouldBe true
         }
     }

--- a/src/test/kotlin/eu/darken/octi/server/common/ParseCapabilitiesHeaderTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/common/ParseCapabilitiesHeaderTest.kt
@@ -1,0 +1,76 @@
+package eu.darken.octi.server.common
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ParseCapabilitiesHeaderTest {
+
+    @Test
+    fun `null or blank returns null`() {
+        parseCapabilitiesHeader(null).shouldBeNull()
+        parseCapabilitiesHeader("").shouldBeNull()
+        parseCapabilitiesHeader("   ").shouldBeNull()
+    }
+
+    @Test
+    fun `valid array decodes into a set`() {
+        val raw = """["encryption:AES256_GCM_SIV","encryption:_reported","encryption:AES256_SIV"]"""
+        parseCapabilitiesHeader(raw)!! shouldContainExactlyInAnyOrder listOf(
+            "encryption:AES256_GCM_SIV",
+            "encryption:_reported",
+            "encryption:AES256_SIV",
+        )
+    }
+
+    @Test
+    fun `empty array decodes to empty set`() {
+        parseCapabilitiesHeader("[]") shouldBe emptySet()
+    }
+
+    @Test
+    fun `non-array element rejected`() {
+        parseCapabilitiesHeader("\"a string\"").shouldBeNull()
+        parseCapabilitiesHeader("42").shouldBeNull()
+        parseCapabilitiesHeader("{\"a\":1}").shouldBeNull()
+    }
+
+    @Test
+    fun `malformed JSON rejected`() {
+        parseCapabilitiesHeader("not json").shouldBeNull()
+        parseCapabilitiesHeader("[unclosed").shouldBeNull()
+    }
+
+    @Test
+    fun `array with non-string element rejected`() {
+        parseCapabilitiesHeader("""["encryption:AES256_GCM_SIV",42]""").shouldBeNull()
+        parseCapabilitiesHeader("""["encryption:AES256_GCM_SIV",null]""").shouldBeNull()
+    }
+
+    @Test
+    fun `array with bad tag shape rejected`() {
+        parseCapabilitiesHeader("""["bad tag"]""").shouldBeNull()
+        parseCapabilitiesHeader("""[":value"]""").shouldBeNull()
+        parseCapabilitiesHeader("""["Encryption:GCM_SIV"]""").shouldBeNull() // uppercase ns
+        parseCapabilitiesHeader("""["encryption:"]""").shouldBeNull()
+    }
+
+    @Test
+    fun `oversized array rejected`() {
+        val tags = (0 until MAX_CAPABILITY_TAGS + 1).joinToString(",") { "\"ns:value$it\"" }
+        parseCapabilitiesHeader("[$tags]").shouldBeNull()
+    }
+
+    @Test
+    fun `tag exceeding max length rejected`() {
+        val tooLong = "encryption:" + "a".repeat(MAX_CAPABILITY_TAG_LENGTH)
+        parseCapabilitiesHeader("""["$tooLong"]""").shouldBeNull()
+    }
+
+    @Test
+    fun `oversized header rejected before parse`() {
+        // Cheap defense — caller doesn't pay parse cost on hostile input.
+        parseCapabilitiesHeader("[" + "x".repeat(MAX_CAPABILITY_HEADER_LENGTH + 1) + "]").shouldBeNull()
+    }
+}

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceFlowTest.kt
@@ -347,6 +347,27 @@ class DeviceFlowTest : TestRunner() {
     }
 
     @Test
+    fun `peer sees other device's capabilities via device list`() = runTest2 {
+        // End-to-end echo: device 2 joins with capabilities, device 1 reads them off the
+        // /v1/devices response. This is the user-visible contract the client-side feature
+        // depends on (peers learning each other's supported encryption modes).
+        val creds1 = createDevice()
+        val shareCode = createShareCode(creds1)
+        val creds2 = createDevice(
+            shareCode = shareCode,
+            capabilities = """["encryption:_reported","encryption:AES256_GCM_SIV"]""",
+        )
+
+        val devices = getDevices(creds1).devices
+        devices.size shouldBe 2
+        val peer = devices.single { it.id == creds2.deviceId }
+        peer.capabilities shouldBe setOf(
+            "encryption:_reported",
+            "encryption:AES256_GCM_SIV",
+        )
+    }
+
+    @Test
     fun `auth failure with missing X-Device-ID is tracked`() = runTest2 {
         http.get(endPoint).apply {
             status shouldBe HttpStatusCode.BadRequest

--- a/src/test/kotlin/eu/darken/octi/server/device/DeviceFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/device/DeviceFlowTest.kt
@@ -273,6 +273,80 @@ class DeviceFlowTest : TestRunner() {
     }
 
     @Test
+    fun `capabilities stored at registration and echoed in device list`() = runTest2 {
+        val caps = """["encryption:AES256_GCM_SIV","encryption:AES256_SIV","encryption:_reported"]"""
+        val creds = createDevice(capabilities = caps)
+        val device = getDevices(creds).devices.single()
+        device.capabilities shouldBe setOf(
+            "encryption:AES256_GCM_SIV",
+            "encryption:AES256_SIV",
+            "encryption:_reported",
+        )
+    }
+
+    @Test
+    fun `capabilities updates on authenticated request`() = runTest2 {
+        val creds = createDevice()
+        getDevices(creds).devices.single().capabilities shouldBe null
+
+        http.get("/v1/devices") {
+            addCredentials(creds)
+            headers.append("Octi-Device-Capabilities", """["encryption:_reported","encryption:AES256_GCM_SIV"]""")
+        }
+
+        getDevices(creds).devices.single().capabilities shouldBe setOf(
+            "encryption:_reported",
+            "encryption:AES256_GCM_SIV",
+        )
+    }
+
+    @Test
+    fun `capabilities not overwritten without header`() = runTest2 {
+        val creds = createDevice(capabilities = """["encryption:_reported","encryption:AES256_GCM_SIV"]""")
+        val initial = setOf("encryption:_reported", "encryption:AES256_GCM_SIV")
+        getDevices(creds).devices.single().capabilities shouldBe initial
+
+        http.get("/v1/devices") {
+            addCredentials(creds)
+        }
+
+        getDevices(creds).devices.single().capabilities shouldBe initial
+    }
+
+    @Test
+    fun `malformed capabilities header treated as absent`() = runTest2 {
+        val creds = createDevice(capabilities = "not json")
+        getDevices(creds).devices.single().capabilities shouldBe null
+    }
+
+    @Test
+    fun `capabilities with invalid tag shape rejects whole set`() = runTest2 {
+        // Mixed valid + invalid tags — entire set is dropped (consistency over partial acceptance).
+        val creds = createDevice(capabilities = """["encryption:AES256_GCM_SIV","BAD TAG"]""")
+        getDevices(creds).devices.single().capabilities shouldBe null
+    }
+
+    @Test
+    fun `capabilities with non-string element rejected`() = runTest2 {
+        val creds = createDevice(capabilities = """["encryption:AES256_GCM_SIV",42]""")
+        getDevices(creds).devices.single().capabilities shouldBe null
+    }
+
+    @Test
+    fun `capabilities with too many tags rejected`() = runTest2 {
+        val tags = (0 until 65).joinToString(",") { "\"ns:value$it\"" }
+        val creds = createDevice(capabilities = "[$tags]")
+        getDevices(creds).devices.single().capabilities shouldBe null
+    }
+
+    @Test
+    fun `empty capabilities array stored as empty set`() = runTest2 {
+        // Empty set is distinct from absent — explicit "I report no capabilities".
+        val creds = createDevice(capabilities = "[]")
+        getDevices(creds).devices.single().capabilities shouldBe emptySet()
+    }
+
+    @Test
     fun `auth failure with missing X-Device-ID is tracked`() = runTest2 {
         http.get(endPoint).apply {
             status shouldBe HttpStatusCode.BadRequest

--- a/src/test/kotlin/eu/darken/octi/server/ws/WsFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/ws/WsFlowTest.kt
@@ -109,6 +109,34 @@ class WsFlowTest : TestRunner() {
     }
 
     @Test
+    fun `connect with Octi-Device-Capabilities stores the capabilities`() = runWsTest {
+        // WS connect goes through the same touchAuthenticatedDevice path as HTTP, but the
+        // wiring is in WsRoute (not HttpExtensions.verifyCaller). Pin it here so the WS
+        // wire claim in the PR description is actually test-covered.
+        val creds = createDevice()
+        val wsClient = createWsClient()
+
+        wsClient.webSocket(
+            urlString = wsUrl(),
+            request = {
+                addCredentials(creds)
+                headers.append(
+                    "Octi-Device-Capabilities",
+                    """["encryption:_reported","encryption:AES256_GCM_SIV"]""",
+                )
+            },
+        ) {
+            close(CloseReason(CloseReason.Codes.NORMAL, "Test done"))
+        }
+
+        getDevices(creds).devices.single().capabilities shouldBe setOf(
+            "encryption:_reported",
+            "encryption:AES256_GCM_SIV",
+        )
+        wsClient.close()
+    }
+
+    @Test
     fun `rate-limited authenticated connect still records client identity`() = runWsTest(
         appConfig = baseConfig.copy(
             port = 16024,


### PR DESCRIPTION
## Summary

Adds server support for the per-device capability tag set introduced client-side in [d4rken-org/octi#309](https://github.com/d4rken-org/octi/pull/309). The server is intentionally a dumb pipe: it parses, validates, persists, and echoes — no knowledge of what individual tag values mean.

Until clients ship the header, this is a no-op (no peer sends `Octi-Device-Capabilities`, so nothing changes). Once the Android client (post-#309) is deployed and other platforms follow suit, the data flows end-to-end and Android peers see each other's capabilities via the existing device-list endpoint.

## Wire contract

- **Header**: `Octi-Device-Capabilities: ["encryption:_reported","encryption:AES256_GCM_SIV","encryption:AES256_SIV"]`
- **Tag shape**: `<namespace>:<value>` — ASCII, lowercase namespace, regex `[a-z][a-z0-9]*:[A-Za-z0-9._\-]+`
- **Limits**: max 64 tags, max 128 chars per tag, max 4096 chars in header value
- **Response**: included as a JSON array on each device in `GET /v1/devices` (proper object, not stringified)

## Behavior

| When | Action |
|---|---|
| `Octi-Device-Capabilities` header present on a state-updating authenticated request | Parse + validate + store on the device |
| Header malformed (bad JSON, wrong shape, oversized, non-array, bad tag) | WARN log, treat as absent — no state change |
| Header absent on a state-updating request | No change (matches existing behavior for version/platform/label) |
| `GET /v1/devices` | Each device's `capabilities` field carries its currently-stored set, or `null` if never reported |

Honored on the same routes that already honor `Octi-Device-Version` / `Octi-Device-Platform` / `Octi-Device-Label`:
- `POST /v1/account` (register / link)
- Heartbeat via `touchAuthenticatedDevice` (any authenticated state-updating request through `HttpExtensions.kt`)
- WebSocket connect (`/v1/ws`)

## Stale-state caveat

Absent-header-on-update follows the existing pattern for label/version/platform: previously-stored capabilities are preserved. If a device downgrades to a client that no longer sends the header, its capabilities remain stale until something explicitly clears them. Acceptable trade-off vs. forcing every request to declare them.

If this becomes a real problem (downgrade scenarios in the wild), a follow-up could clear capabilities whenever the device's `version` or `platform` changes without an accompanying `Octi-Device-Capabilities` header.

## Validation rationale

The validation mirrors the client-side codec in [octi#309](https://github.com/d4rken-org/octi/pull/309) — same regex, same limits. Server-side validation is defense in depth: a misbehaving client (or hostile substrate) could otherwise pollute on-disk JSON and amplify peer-side error logs. On any bad tag the whole set is rejected (no partial acceptance) so consumers get either valid data or nothing — no surprise dropped tags.

## Test plan

- [x] `./gradlew test` — all pass.
- [x] New `ParseCapabilitiesHeaderTest` covers each rejection path: null/blank, malformed JSON, non-array, non-string element, bad tag shape, oversize set, oversize tag, oversize header. Plus happy-path roundtrip and empty-array → empty-set.
- [x] `DeviceFlowTest` extended: capabilities stored at register; updated on authenticated request; preserved when header absent; rejected on malformed JSON / bad tag / non-string / oversize; empty array → empty set.
- [x] `CorsFlowTest.preflight` updated so the SPA can include `Octi-Device-Capabilities` in its preflight.
- [ ] Manual integration with the Android client running [octi#309](https://github.com/d4rken-org/octi/pull/309) once this is deployed.
