### PR TITLE
Ignore .claude/worktrees/

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,1 +1,2 @@
 scheduled_tasks.lock
+worktrees/


### PR DESCRIPTION
Local Claude Code session worktrees land under `.claude/worktrees/`. Add them to `.claude/.gitignore` alongside `scheduled_tasks.lock` so they're never staged.

No code/runtime impact — single ignore-rule addition.