### PR TITLE
fix: use setup-gradle for Gradle caching in CI

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -13,21 +13,11 @@ runs:
       shell: bash
       run: chmod +x gradlew
 
-    - name: Cache Gradle Wrapper
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
-      with:
-        path: |
-          ~/.gradle/wrapper
-          !~/.gradle/wrapper/dists/**/gradle*.zip
-        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-wrapper-
-
-    - name: Cache Gradle Dependencies
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
-      with:
-        path: |
-          ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'buildSrc/**/*.kt') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-caches-
+    # Use gradle/actions/setup-gradle for caching: it resolves GRADLE_USER_HOME
+    # correctly whether the job runs on the host runner (~ = /home/runner) or
+    # inside a container job (~ = /root), and produces a sane cache key from
+    # the Gradle build files. The previous manual actions/cache step targeted
+    # ~/.gradle/{wrapper,caches} which doesn't exist in container jobs and
+    # emitted "Path Validation Error" warnings — so caches were never saved.
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e #v6.1.0


### PR DESCRIPTION
## Summary

Every `Run tests` CI job emits:

```
[warning]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

Root cause: the `run-tests` job in `code-checks.yml` runs inside `container: ubuntu:24.04`. The `actions/cache` steps in `.github/actions/common-setup/action.yml` target `~/.gradle/wrapper` and `~/.gradle/caches`, which resolve to a container-local home dir that does not match where Gradle actually writes its caches in CI. `actions/cache` validates the paths at save time, finds nothing, warns, and skips the save. The Gradle cache is therefore never persisted between runs (the audit estimates ~8min added to `:check` each time).

## Fix

Replace the two manual `actions/cache` steps with a single `gradle/actions/setup-gradle@v6.1.0` step. This action:

- Auto-detects `GRADLE_USER_HOME` correctly on both host runners and container jobs.
- Uses Gradle-aware cache keys (no manual `hashFiles` glob to maintain).
- Is the Gradle-team-recommended approach and supersedes the older manual `actions/cache` pattern.

Pinned to `50e97c2cd7a37755bbfafc9c5b7cafaece252f6e` (`#v6.1.0`), the same SHA already used by `gradle-wrapper-validation.yml`.

## Follow-up (not in this PR)

The build also surfaces:

> Consider enabling configuration cache to speed up this build

That requires Gradle code changes to verify all tasks are config-cache compatible, so it's out of scope here. Tracked as a separate follow-up.

## Test plan

- [ ] CI runs without the `Path Validation Error` warning
- [ ] Second CI run on this branch reports a cache hit (`gradle/actions/setup-gradle` logs `Restored Gradle User Home from cache`)
- [ ] All existing jobs (`build-modules`, `build-docker-image`, `run-tests`, `regression-synthetic-replay`) still pass
