### PR TITLE
Fix canary release target_commitish on gh release calls

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -140,6 +140,7 @@ jobs:
       - name: Update rolling canary pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
           TAG: ${{ steps.canary-meta.outputs.tag }}
           TITLE: ${{ steps.canary-meta.outputs.title }}
           NOTES_FILE: ${{ steps.canary-meta.outputs.notes_file }}
@@ -147,7 +148,7 @@ jobs:
           set -euo pipefail
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" octi-server-canary.zip --clobber
-            gh release edit "$TAG" --title "$TITLE" --notes-file "$NOTES_FILE" --prerelease --target "$TAG"
+            gh release edit "$TAG" --title "$TITLE" --notes-file "$NOTES_FILE" --prerelease
           else
-            gh release create "$TAG" octi-server-canary.zip --title "$TITLE" --notes-file "$NOTES_FILE" --prerelease --target "$TAG"
+            gh release create "$TAG" octi-server-canary.zip --title "$TITLE" --notes-file "$NOTES_FILE" --prerelease --target "$SHA" --verify-tag
           fi


### PR DESCRIPTION
## Summary
- The first canary run on main failed at the final `Update rolling canary pre-release` step with `HTTP 422 Release.target_commitish is invalid`
- Cause: `--target "$TAG"` passed the literal string `canary` as target_commitish, which gh interprets as a branch name
- Switch `gh release create` to `--target "$SHA" --verify-tag` and drop `--target` from `gh release edit` since the canary tag is already moved to that commit by the preceding step

## Current main state after the failed first run
- GHCR `:canary` and `:sha-469e167` — published
- Git tag `canary` — points at 469e167
- GitHub release `canary` — not yet created (this PR's merge run will create it)

## Test plan
- YAML parses
- Next push to main re-runs the workflow; `gh release create` should now succeed and create the rolling pre-release