### PR TITLE
Expose X-Modified-At via CORS for module reads

### DIFF
--- a/src/main/kotlin/eu/darken/octi/server/Server.kt
+++ b/src/main/kotlin/eu/darken/octi/server/Server.kt
@@ -100,6 +100,13 @@ class Server @Inject constructor(
                     allowHeader("Upload-Offset")
                     exposeHeader(HttpHeaders.ETag)
                     exposeHeader(HttpHeaders.LastModified)
+                    // ModuleRoute sets X-Modified-At with the payload's server-side
+                    // modification timestamp. Browsers can only read non-safelisted
+                    // response headers cross-origin when they're listed here.
+                    // octi-web's multi-connector merge uses it to order data when the
+                    // same peer device is reachable via two connectors — newest
+                    // X-Modified-At per (deviceId, moduleId) wins.
+                    exposeHeader("X-Modified-At")
                     exposeHeader(HttpHeaders.ContentRange)
                     exposeHeader(HttpHeaders.AcceptRanges)
                     exposeHeader(HttpHeaders.RetryAfter)

--- a/src/test/kotlin/eu/darken/octi/server/common/CorsFlowTest.kt
+++ b/src/test/kotlin/eu/darken/octi/server/common/CorsFlowTest.kt
@@ -128,6 +128,7 @@ class CorsFlowTest : TestRunner() {
                 "upload-expires",
                 "upload-state",
                 "x-blob-id",
+                "x-modified-at",
             )
             withClue("Access-Control-Expose-Headers='$exposed' missing: ${expected.filterNot { it in exposed }}") {
                 expected.forEach { (it in exposed) shouldBe true }


### PR DESCRIPTION
## Summary

Add `X-Modified-At` to `Access-Control-Expose-Headers` so cross-origin browsers can read the header that `ModuleRoute` already sets on `GET` `/v1/module/{moduleId}`.

`ModuleFlowTest` and `ModuleMigrationTest` already pin that the header is sent. `CorsFlowTest` pins which headers are exposed cross-origin — this PR adds the new entry to that list.

## Why

octi-web's multi-connector merge orders peer data by newest `X-Modified-At` per `(deviceId, moduleId)`. Without CORS exposure, `response.headers.get("X-Modified-At")` returns `null` for the deployed cross-origin client (`web.octi.darken.eu` → `prod.kserver.octi.darken.eu`), and the merge falls back to a deterministic tiebreak on `connectorId` only — semantically arbitrary.

This unblocks the multi-connector port on web. Same-origin / localhost dev was unaffected (CORS doesn't strip headers there).

## Sister PR

- d4rken-org/octi-web#21 — already merged. Adds the client-side parsing of `X-Modified-At`; this server PR makes it actually visible cross-origin.

## Test plan

- [x] `./gradlew test --tests "eu.darken.octi.server.common.CorsFlowTest"` — green (asserts `x-modified-at` is now in `Access-Control-Expose-Headers`)
- [x] `./gradlew test --tests "eu.darken.octi.server.module.ModuleFlowTest" --tests "eu.darken.octi.server.module.ModuleMigrationTest"` — green (header still set on responses)
